### PR TITLE
gen_matrix_avx2: enforce transposed in range [0; 1]

### DIFF
--- a/code/jasmin/mlkem_avx2/extraction/jkem_avx2.ec
+++ b/code/jasmin/mlkem_avx2/extraction/jkem_avx2.ec
@@ -9522,6 +9522,7 @@ module M(SC:Syscall_t) = {
     buf_s <- witness;
     pol <- witness;
     polx4 <- witness;
+    transposed <- (transposed `&` (W64.of_int 1));
     (* Erased call to spill *)
     buf <- buf_s;
     i <- 0;

--- a/code/jasmin/mlkem_avx2/gen_matrix.jinc
+++ b/code/jasmin/mlkem_avx2/gen_matrix.jinc
@@ -467,6 +467,9 @@ export fn _gen_matrix_avx2
   reg u64 pos_entry;
   reg u16 rc;
 
+  // Enforce small range
+  transposed &= 1;
+
   () = #spill(transposed);
 
   buf = buf_s;

--- a/code/jasmin/mlkem_avx2_stack/extraction/jkem_avx2_stack.ec
+++ b/code/jasmin/mlkem_avx2_stack/extraction/jkem_avx2_stack.ec
@@ -9189,6 +9189,7 @@ module M = {
     buf_s <- witness;
     pol <- witness;
     polx4 <- witness;
+    transposed <- (transposed `&` (W64.of_int 1));
     (* Erased call to spill *)
     buf <- buf_s;
     i <- 0;

--- a/proof/correctness/avx2/MLKEM_genmatrix_avx2.ec
+++ b/proof/correctness/avx2/MLKEM_genmatrix_avx2.ec
@@ -1134,7 +1134,7 @@ while (0<=i<=3 /\ rho = _sd /\
    rewrite /subarray256 /subarray768  tP => *.
    by rewrite initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# initiE 1:/# /= ifF /#. 
 
-wp 13.
+wp 14.
 conseq (_:  (forall kk, 0 <= kk < 3 =>  subarray768 matrix kk = (subarray768 (unlift_matrix (if b then trmx (sampleA _sd) else (sampleA _sd))) kk))).
 move =>/> m0 H; split;1:smt().
 case b => hb.
@@ -1155,12 +1155,14 @@ case (768 <= k && k < 1536).
 + by move =>? kbb;rewrite -H0 1:/# /subarray768 initiE 1:/# /=.  
 by move =>? kbb;rewrite -H0 1:/# /subarray768 initiE 1:/# /=.
 
-unroll for 7.
+unroll for ^while.
 wp;call (sample_last _sd). 
 wp;call (sample_four _sd 4 b _).
 wp;call (sample_four _sd 0 b _).
 
-auto => /> &hr a -> a0 -> a1 -> row ??.
+auto => &hr [] -> ->.
+have -> : W64.of_int (b2i b) `&` W64.one = W64.of_int (b2i b) by case: b.
+move => /> a -> a0 -> a1 -> row ??.
 congr; rewrite tP => kk ?.
 pose xx := (unlift_matrix (if b then trmx (sampleA _sd) else sampleA _sd)).[kk].
 rewrite initiE 1:/# /=.


### PR DESCRIPTION
The `transposed` argument to the (export) function gen_matrix_avx2 is used to index an array. It is a therefore a requirement for safety that its value is in the range of booleans [0; 1].

This change removes this requirement by “clamping” the value before any use.