### PR TITLE
Remove redundant casts to int in array indices

### DIFF
--- a/code/jasmin/768/ref/polyvec.jinc
+++ b/code/jasmin/768/ref/polyvec.jinc
@@ -19,7 +19,7 @@ fn __polyvec_compress(reg u64 rp, stack u16[MLKEM_VECN] a)
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -81,7 +81,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
   {
     for k = 0 to 4
     {
-      t[k] = (64u)aa[(int) i];
+      t[k] = (64u)aa[i];
       i += 1;
       t[k] <<= 10;
       t[k] += 1665;
@@ -92,7 +92,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
 
     c = t[0];
     c &= 0xff;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[0];
@@ -100,7 +100,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     c = t[1];
     c <<= 2;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[1];
@@ -108,7 +108,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     c = t[2];
     c <<= 4;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     b = t[2];
@@ -116,11 +116,11 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     c = t[3];
     c <<= 6;
     c |= b;
-    rp[(int) j] = c;
+    rp[j] = c;
     j += 1;
 
     t[3] >>= 2;
-    rp[(int) j] = t[3];
+    rp[j] = t[3];
     j += 1;
   }
 
@@ -174,7 +174,7 @@ fn __polyvec_decompress(reg u64 ap) -> stack u16[MLKEM_VECN]
       t[k] *= MLKEM_Q;
       t[k] += 512;
       t[k] >>= 10;
-      r[(int) i] = t[k];
+      r[i] = t[k];
       i += 1;
     }
   }

--- a/code/jasmin/common/avx2/gen_matrix.jinc
+++ b/code/jasmin/common/avx2/gen_matrix.jinc
@@ -133,14 +133,14 @@ inline fn __gen_matrix_buf_rejection_filter48
   t0_0 = good;
   t0_0 &= 0xFF; // g0[0..7]
 
-  shuffle_0 = (256u) #VMOV(sst[u64 (int)t0_0]);
+  shuffle_0 = (256u) #VMOV(sst[u64 t0_0]);
   ?{}, t0_0 = #POPCNT_64(t0_0);
   t0_0 += counter;
 
   t0_1 = good;
   t0_1 >>= 16;
   t0_1 &= 0xFF; // g0[8..15]
-  shuffle_0_1 = #VMOV(sst[u64 (int)t0_1]);
+  shuffle_0_1 = #VMOV(sst[u64 t0_1]);
   ?{}, t0_1 = #POPCNT_64(t0_1);
   t0_1 += t0_0;
 
@@ -148,14 +148,14 @@ inline fn __gen_matrix_buf_rejection_filter48
   t1_0 = good;
   t1_0 >>= 8;
   t1_0 &= 0xFF; // g1[0..7]
-  shuffle_1 = (256u) #VMOV(sst[u64 (int)t1_0]);
+  shuffle_1 = (256u) #VMOV(sst[u64 t1_0]);
   ?{}, t1_0 = #POPCNT_64(t1_0);
   t1_0 += t0_1;
 
   t1_1 = good;
   t1_1 >>= 24;
   t1_1 &= 0xFF; // g1[8..15]
-  shuffle_1_1 = #VMOV(sst[u64 (int)t1_1]);
+  shuffle_1_1 = #VMOV(sst[u64 t1_1]);
   ?{}, t1_1 = #POPCNT_64(t1_1);
   t1_1 += t1_0;
 
@@ -275,14 +275,14 @@ inline fn __gen_matrix_buf_rejection_filter24
   // g0
   t0_0 = good;
   t0_0 &= 0xFF; // g0[0..7]
-  shuffle_0 = (256u) #VMOV(sst[u64 (int)t0_0]);
+  shuffle_0 = (256u) #VMOV(sst[u64 t0_0]);
   ?{}, t0_0 = #POPCNT_64(t0_0);
   t0_0 += counter;
 
   t0_1 = good;
   t0_1 >>= 16;
   t0_1 &= 0xFF; // g0[8..15]
-  shuffle_0_1 = #VMOV(sst[u64 (int)t0_1]);
+  shuffle_0_1 = #VMOV(sst[u64 t0_1]);
   ?{}, t0_1 = #POPCNT_64(t0_1);
   t0_1 += t0_0;
 

--- a/code/jasmin/common/ref/gen_matrix.jinc
+++ b/code/jasmin/common/ref/gen_matrix.jinc
@@ -138,7 +138,7 @@ fn __gen_matrix(stack u8[MLKEM_SYMBYTES] seed, reg u64 transposed) -> stack u16[
       rij = r[i * MLKEM_VECN + j * MLKEM_N : MLKEM_N];
       while (k < MLKEM_N)
       {
-        t = poly[(int) k];
+        t = poly[k];
         rij[k] = t;
         k += 1;
       }

--- a/code/jasmin/common/ref/poly.jinc
+++ b/code/jasmin/common/ref/poly.jinc
@@ -12,10 +12,10 @@ fn _poly_add2(reg mut ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] bp) -> reg
 
   i = 0;
   while (i < MLKEM_N) {
-    a = rp[(int)i];
-    b = bp[(int)i];
+    a = rp[i];
+    b = bp[i];
     r = a + b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -30,13 +30,13 @@ fn _poly_csubq(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   i = 0;
   while (i < MLKEM_N)
   {
-    t = rp[(int)i];
+    t = rp[i];
     t -= MLKEM_Q;
     b = t;
     b >>s= 15;
     b &= MLKEM_Q;
     t += b;
-    rp[(int)i] = t;
+    rp[i] = t;
     i += 1;
   }
   return rp;
@@ -68,11 +68,11 @@ fn _poly_basemul(reg ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] ap bp) -> r
     zetasctr >>= 2;
     zeta = zetasp[zetasctr];
 
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -85,19 +85,19 @@ fn _poly_basemul(reg ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
 
     zeta = -zeta;
 
     i += 1;
-    a0 = ap[(int)i];
-    b0 = bp[(int)i];
+    a0 = ap[i];
+    b0 = bp[i];
     i += 1;
-    a1 = ap[(int)i];
-    b1 = bp[(int)i];
+    a1 = ap[i];
+    b1 = bp[i];
     i -= 1;
 
     r0 = __fqmul(a1, b1);
@@ -110,9 +110,9 @@ fn _poly_basemul(reg ptr u16[MLKEM_N] rp, reg const ptr u16[MLKEM_N] ap bp) -> r
     r1 += t;
 
     rp = srp;
-    rp[(int)i]   = r0;
+    rp[i]   = r0;
     i += 1;
-    rp[(int)i] = r1;
+    rp[i] = r1;
     srp = rp;
 
     i += 1;
@@ -129,9 +129,9 @@ fn __poly_reduce(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   j = 0;
   while (j < MLKEM_N)
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __barrett_reduce(t);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -177,9 +177,9 @@ fn _poly_frommont(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   i = 0;
   while (i < MLKEM_N)
   {
-    r = rp[(int)i];
+    r = rp[i];
     r = __fqmul(r, dmont);
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -389,22 +389,22 @@ fn _poly_invntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
     start = 0;
     while (start < 256)
     {
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       zetasctr += 1;
 
       j = start;
       cmp = start; cmp += len;
       while (j < cmp)
       {
-        t = rp[(int)j];
+        t = rp[j];
         offset = j; offset += len;
-        s = rp[(int)offset];
+        s = rp[offset];
         m = s; m += t;
         m = __barrett_reduce(m);
-        rp[(int)j] = m;
+        rp[j] = m;
         t -= s;
         t = __fqmul(t, zeta);
-        rp[(int)offset] = t;
+        rp[offset] = t;
         j += 1;
       }
       start = j; start += len;
@@ -416,9 +416,9 @@ fn _poly_invntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
   j = 0;
   while (j < MLKEM_N)
   {
-    t = rp[(int)j];
+    t = rp[j];
     t = __fqmul(t, zeta);
-    rp[(int)j] = t;
+    rp[j] = t;
     j += 1;
   }
   return rp;
@@ -449,20 +449,20 @@ fn _poly_ntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
     while (start < 256)
     {
       zetasctr += 1;
-      zeta = zetasp[(int)zetasctr];
+      zeta = zetasp[zetasctr];
       j = start;
       cmp = start; cmp += len;
       while (j < cmp)
       {
-        s = rp[(int)j];
+        s = rp[j];
         m = s;
         offset = j; offset += len;
-        t = rp[(int)offset];
+        t = rp[offset];
         t = __fqmul(t, zeta);
         m -= t;
         t += s;
-        rp[(int)offset] = m;
-        rp[(int)j] = t;
+        rp[offset] = m;
+        rp[j] = t;
         j += 1;
       }
       start = j; start += len;
@@ -484,10 +484,10 @@ fn _poly_sub(reg ptr u16[MLKEM_N] rp ap bp) -> reg ptr u16[MLKEM_N]
 
   i = 0;
   while (i < MLKEM_N) {
-    a = ap[(int)i];
-    b = bp[(int)i];
+    a = ap[i];
+    b = bp[i];
     r = a - b;
-    rp[(int)i] = r;
+    rp[i] = r;
     i += 1;
   }
   return rp;
@@ -504,9 +504,9 @@ fn _poly_tobytes(reg u64 rp, reg ptr u16[MLKEM_N] a) -> reg ptr u16[MLKEM_N]
   j = 0;
   while (i < MLKEM_N)
   {
-    t0 = a[(int)i];
+    t0 = a[i];
     i += 1;
-    t1 = a[(int)i];
+    t1 = a[i];
     i += 1;
     d  = t0;
     d  &= 0xff;


### PR DESCRIPTION
These casts are not needed and use a deprecated syntax.