### PR TITLE
Use #BLENDV instead of #VPBLENDVB

### DIFF
--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -8999,7 +8999,7 @@ module M(SC:Syscall_t) = {
       f0 <- (VPSHUFB_256 f0 shufbidx);
       t0 <- (truncateu128 f0);
       t1 <- (VEXTRACTI128 f0 (W8.of_int 1));
-      t0 <- (VPBLENDVB_128 t0 t1 (truncateu128 shufbidx));
+      t0 <- (BLENDV_16u8 t0 t1 (truncateu128 shufbidx));
       Glob.mem <-
       (storeW128 Glob.mem (W64.to_uint (rp + (W64.of_int (20 * i)))) t0);
       Glob.mem <-
@@ -9054,7 +9054,7 @@ module M(SC:Syscall_t) = {
       f0 <- (VPSHUFB_256 f0 shufbidx);
       t0 <- (truncateu128 f0);
       t1 <- (VEXTRACTI128 f0 (W8.of_int 1));
-      t0 <- (VPBLENDVB_128 t0 t1 (truncateu128 shufbidx));
+      t0 <- (BLENDV_16u8 t0 t1 (truncateu128 shufbidx));
       rp <-
       (Array160.init
       (WArray160.get8
@@ -9375,7 +9375,7 @@ module M(SC:Syscall_t) = {
       f0 <- (VPSHUFB_256 f0 shufbidx);
       t0 <- (truncateu128 f0);
       t1 <- (VEXTRACTI128 f0 (W8.of_int 1));
-      t0 <- (VPBLENDVB_128 t0 t1 (truncateu128 shufbidx));
+      t0 <- (BLENDV_16u8 t0 t1 (truncateu128 shufbidx));
       Glob.mem <-
       (storeW128 Glob.mem (W64.to_uint (rp + (W64.of_int (22 * i)))) t0);
       Glob.mem <-
@@ -9440,7 +9440,7 @@ module M(SC:Syscall_t) = {
       f0 <- (VPSHUFB_256 f0 shufbidx);
       t0 <- (truncateu128 f0);
       t1 <- (VEXTRACTI128 f0 (W8.of_int 1));
-      t0 <- (VPBLENDVB_128 t0 t1 (truncateu128 shufbidx));
+      t0 <- (BLENDV_16u8 t0 t1 (truncateu128 shufbidx));
       rp <-
       (Array1408.init
       (WArray1408.get8
@@ -10514,7 +10514,7 @@ module M(SC:Syscall_t) = {
     while ((i < inc)) {
       f <- (get256_direct (WArray32.init8 (fun i_0 => src.[i_0])) (32 * i));
       g <- (loadW256 Glob.mem (W64.to_uint (dst + (W64.of_int (32 * i)))));
-      f <- (VPBLENDVB_256 f g m);
+      f <- (BLENDV_32u8 f g m);
       Glob.mem <-
       (storeW256 Glob.mem (W64.to_uint (dst + (W64.of_int (32 * i)))) f);
       i <- (i + 1);

--- a/code/jasmin/1024/avx2/poly.jinc
+++ b/code/jasmin/1024/avx2/poly.jinc
@@ -58,7 +58,7 @@ fn _poly_compress(reg u64 rp, reg ptr u16[MLKEM_N] a) -> reg ptr u16[MLKEM_N]
     f0 = #VPSHUFB_256(f0, shufbidx);
     t0 = (128u)f0;
     t1 = #VEXTRACTI128(f0, 1);
-    t0 = #VPBLENDVB_128(t0, t1, (128u)shufbidx);
+    t0 = #BLENDV_16u8(t0, t1, (128u)shufbidx);
     (u128)[rp + 20*i] = t0;
     (u32)[rp + 20*i + 16] = (32u)t1;
   }
@@ -106,7 +106,7 @@ fn _poly_compress_1(reg ptr u8[MLKEM_POLYCOMPRESSEDBYTES] rp, reg ptr u16[MLKEM_
     f0 = #VPSHUFB_256(f0, shufbidx);
     t0 = (128u)f0;
     t1 = #VEXTRACTI128(f0, 1);
-    t0 = #VPBLENDVB_128(t0, t1, (128u)shufbidx);
+    t0 = #BLENDV_16u8(t0, t1, (128u)shufbidx);
     rp.[u128 20*i] = t0;
     rp.[u32 20*i + 16] = (32u)t1;
   }

--- a/code/jasmin/1024/avx2/polyvec.jinc
+++ b/code/jasmin/1024/avx2/polyvec.jinc
@@ -126,7 +126,7 @@ fn __polyvec_compress(reg u64 rp, stack u16[MLKEM_VECN] a)
     f0 = #VPSHUFB_256(f0, shufbidx);
     t0 = (128u)f0;
     t1 = #VEXTRACTI128(f0, 1);
-    t0 = #VPBLENDVB_128(t0, t1, (128u)shufbidx);
+    t0 = #BLENDV_16u8(t0, t1, (128u)shufbidx);
     (u128)[rp + 22*i] = t0;
     (u64)[rp + 22*i + 16] = (64u)t1;
   }
@@ -178,7 +178,7 @@ fn __polyvec_compress_1(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     f0 = #VPSHUFB_256(f0, shufbidx);
     t0 = (128u)f0;
     t1 = #VEXTRACTI128(f0, 1);
-    t0 = #VPBLENDVB_128(t0, t1, (128u)shufbidx);
+    t0 = #BLENDV_16u8(t0, t1, (128u)shufbidx);
     rp.[u128 22*i] = t0;
     rp.[u64 22*i + 16] = (64u)t1;
   }

--- a/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
+++ b/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
@@ -8752,7 +8752,7 @@ module M = {
       f0 <- (VPSHUFB_256 f0 shufbidx);
       t0 <- (truncateu128 f0);
       t1 <- (VEXTRACTI128 f0 (W8.of_int 1));
-      t0 <- (VPBLENDVB_128 t0 t1 (truncateu128 shufbidx));
+      t0 <- (BLENDV_16u8 t0 t1 (truncateu128 shufbidx));
       rp <-
       (Array160.init
       (WArray160.get8
@@ -9093,7 +9093,7 @@ module M = {
       f0 <- (VPSHUFB_256 f0 shufbidx);
       t0 <- (truncateu128 f0);
       t1 <- (VEXTRACTI128 f0 (W8.of_int 1));
-      t0 <- (VPBLENDVB_128 t0 t1 (truncateu128 shufbidx));
+      t0 <- (BLENDV_16u8 t0 t1 (truncateu128 shufbidx));
       rp <-
       (Array1408.init
       (WArray1408.get8
@@ -10007,7 +10007,7 @@ module M = {
     m <- (VPBROADCAST_4u64 scnd);
     f <- (get256_direct (WArray32.init8 (fun i => src.[i])) 0);
     g <- (get256_direct (WArray32.init8 (fun i => dst.[i])) 0);
-    f <- (VPBLENDVB_256 f g m);
+    f <- (BLENDV_32u8 f g m);
     dst <-
     (Array32.init
     (WArray32.get8

--- a/code/jasmin/1024/avx2_stack/poly.jinc
+++ b/code/jasmin/1024/avx2_stack/poly.jinc
@@ -45,7 +45,7 @@ fn _i_poly_compress(reg ptr u8[MLKEM_POLYCOMPRESSEDBYTES] rp, reg ptr u16[MLKEM_
     f0 = #VPSHUFB_256(f0, shufbidx);
     t0 = (128u)f0;
     t1 = #VEXTRACTI128(f0, 1);
-    t0 = #VPBLENDVB_128(t0, t1, (128u)shufbidx);
+    t0 = #BLENDV_16u8(t0, t1, (128u)shufbidx);
     rp.[u128 20*i] = t0;
     rp.[u32 20*i + 16] = (32u)t1;
   }

--- a/code/jasmin/1024/avx2_stack/polyvec.jinc
+++ b/code/jasmin/1024/avx2_stack/polyvec.jinc
@@ -106,7 +106,7 @@ fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[M
     f0 = #VPSHUFB_256(f0, shufbidx);
     t0 = (128u)f0;
     t1 = #VEXTRACTI128(f0, 1);
-    t0 = #VPBLENDVB_128(t0, t1, (128u)shufbidx);
+    t0 = #BLENDV_16u8(t0, t1, (128u)shufbidx);
     rp.[u128 22*i] = t0;
     rp.[u64 22*i + 16] = (64u)t1;
   }

--- a/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
+++ b/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
@@ -10125,7 +10125,7 @@ module M(SC:Syscall_t) = {
     while ((i < inc)) {
       f <- (get256_direct (WArray32.init8 (fun i_0 => src.[i_0])) (32 * i));
       g <- (loadW256 Glob.mem (W64.to_uint (dst + (W64.of_int (32 * i)))));
-      f <- (VPBLENDVB_256 f g m);
+      f <- (BLENDV_32u8 f g m);
       Glob.mem <-
       (storeW256 Glob.mem (W64.to_uint (dst + (W64.of_int (32 * i)))) f);
       i <- (i + 1);

--- a/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
+++ b/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
@@ -9675,7 +9675,7 @@ module M = {
     m <- (VPBROADCAST_4u64 scnd);
     f <- (get256_direct (WArray32.init8 (fun i => src.[i])) 0);
     g <- (get256_direct (WArray32.init8 (fun i => dst.[i])) 0);
-    f <- (VPBLENDVB_256 f g m);
+    f <- (BLENDV_32u8 f g m);
     dst <-
     (Array32.init
     (WArray32.get8

--- a/code/jasmin/common/avx2/verify.jinc
+++ b/code/jasmin/common/avx2/verify.jinc
@@ -81,7 +81,7 @@ fn __cmov(reg u64 dst, reg ptr u8[MLKEM_SYMBYTES] src, reg u64 cnd)
   {
     f = src.[u256 32*i];
     g = (u256)[dst + 32*i];
-    f = #VPBLENDVB_256(f, g, m);
+    f = #BLENDV_32u8(f, g, m);
     (u256)[dst + 32*i] = f;
   }
 }

--- a/code/jasmin/common/avx2_stack/verify.jinc
+++ b/code/jasmin/common/avx2_stack/verify.jinc
@@ -40,7 +40,7 @@ fn __cmov(reg ptr u8[MLKEM_SYMBYTES] dst, reg ptr u8[MLKEM_SYMBYTES] src, reg u6
 
   f = src.[u256 0];
   g = dst.[u256 0];
-  f = #VPBLENDVB_256(f, g, m);
+  f = #BLENDV_32u8(f, g, m);
   dst.[u256 0] = f;
 
   return dst;

--- a/proof/correctness768/avx2/MLKEM_KEM_avx2.ec
+++ b/proof/correctness768/avx2/MLKEM_KEM_avx2.ec
@@ -548,26 +548,26 @@ do split.
 
 + move =>czero; move : (H1 czero) => -> /=;rewrite tP => k kb.
 rewrite initiE //= /storeW256 /=.
-have HH : forall ii, 0<=ii <32 => VPBLENDVB_256 ((WArray32.WArray32.get256_direct ((WArray32.WArray32.init8 ("_.[_]" _src))) 0))
+have HH : forall ii, 0<=ii <32 => BLENDV_32u8 ((WArray32.WArray32.get256_direct ((WArray32.WArray32.init8 ("_.[_]" _src))) 0))
           (loadW256 mem (to_uint dst{hr})) (VPBROADCAST_4u64 W64.zero) \bits8
         ii = _src.[ii]; last first. 
 + rewrite !HH //=.
   by rewrite /loadW8 /stores /= !get_setE /= /#.
 move => ii iib.
 rewrite /get256_direct /init8 /loadW256 /loadW8 /= wordP => i ib.
-rewrite /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /VPBLENDVB_128 /= !msb0 //=  initiE //=.
+rewrite /BLENDV_32u8 /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /BLENDV_16u8 /VPBLENDVB_128 /= !msb0 //=  initiE //=.
 rewrite pack32E initiE /= 1:/# /of_list initiE /= /#.
  
 + move =>cone; move : (H2 cone) => -> /=;rewrite tP => k kb.
 rewrite initiE //= /storeW256 /=.
-have HH : forall ii, 0<=ii <32 => VPBLENDVB_256 ((WArray32.WArray32.get256_direct ((WArray32.WArray32.init8 ("_.[_]" _src))) 0))
+have HH : forall ii, 0<=ii <32 => BLENDV_32u8 ((WArray32.WArray32.get256_direct ((WArray32.WArray32.init8 ("_.[_]" _src))) 0))
         (loadW256 mem (to_uint dst{hr})) (VPBROADCAST_4u64 W64.onew) \bits8
               ii = ((init (fun (i0 : int) => loadW8 mem (to_uint dst{hr} + i0))))%Array32.[ii]; last first. 
 + rewrite !HH //=.
   by rewrite initiE //= /loadW8 /stores /= !get_setE /= /#.
 move => ii iib.
 rewrite /get256_direct /init8 /loadW256 /loadW8 /= wordP => i ib.
-rewrite /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /VPBLENDVB_128 /= !msb1 //=  initiE //=.
+rewrite /BLENDV_32u8 /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /BLENDV_16u8 /VPBLENDVB_128 /= !msb1 //=  initiE //=.
 by rewrite pack32E initiE /= 1:/# /of_list !initiE /= /#.
 qed.
 

--- a/proof/correctness768/avx2/MLKEM_KEM_avx2_stack.ec
+++ b/proof/correctness768/avx2/MLKEM_KEM_avx2_stack.ec
@@ -493,13 +493,13 @@ do split.
 + rewrite tP => H1 k  kb;rewrite (H H1).
   rewrite initiE 1:/# /= kb /=.
 rewrite /get256_direct /init8 /loadW256 /loadW8 /= wordP => i ib.
-rewrite /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /VPBLENDVB_128 /=  initiE 1:/# /=.
+rewrite /BLENDV_32u8 /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /BLENDV_16u8 /VPBLENDVB_128 /=  initiE 1:/# /=.
 by rewrite !msb0 1..8:/# pack32E initiE /= 1:/# /of_list initiE /= /#.
  
 + move =>cone; move : (H0 cone) => -> /=;rewrite tP => k kb.
 rewrite initiE 1:/# /= kb /=.
 rewrite /get256_direct /init8 /loadW256 /loadW8 /= wordP => i ib.
-rewrite /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /VPBLENDVB_128 /= !msb1 //=  initiE //=.
+rewrite /BLENDV_32u8 /VPBLENDVB_256 /VPBROADCAST_4u64 /(\bits8) -iotaredE /= /BLENDV_16u8 /VPBLENDVB_128 /= !msb1 //=  initiE //=.
 by rewrite pack32E initiE /= 1:/# /of_list !initiE /= /#.
 qed.
 


### PR DESCRIPTION
The #VPBLENDVB intrinsic has been deprecated since Jasmin 2024.07.3 (released in February 2025).