### PR TITLE
Gen-matrix (AVX2) is constant-time

### DIFF
--- a/code/jasmin/1024/avx2/Makefile
+++ b/code/jasmin/1024/avx2/Makefile
@@ -42,6 +42,7 @@ test/speed_kem: test/speed_kem.c $(JINC) $(SOURCES) jkem.s
 .PHONY: ct clean
 
 ct:
+	$(JASMINCT) gen_matrix.jazz
 	$(JASMINCT) --infer jkem.jazz
 
 sct:

--- a/code/jasmin/1024/avx2/gen_matrix.jazz
+++ b/code/jasmin/1024/avx2/gen_matrix.jazz
@@ -34,10 +34,10 @@ fn _gen_matrix_avx2_nounpack
 }
 
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_gen_matrix(
-    reg mut ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] matrix, 
-    reg const ptr u8[32] rho, 
-    #spill_to_mmx reg u64 transposed
-) -> reg ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] {
+    #secret reg mut ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] matrix,
+    #secret reg const ptr u8[32] rho,
+    #public #spill_to_mmx reg u64 transposed
+) -> #secret reg ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] {
    transposed &= 1;
    matrix = _gen_matrix_avx2_nounpack(matrix,rho,transposed);
    return matrix;

--- a/code/jasmin/768/avx2/Makefile
+++ b/code/jasmin/768/avx2/Makefile
@@ -42,6 +42,7 @@ test/speed_kem: test/speed_kem.c $(JINC) $(SOURCES) jkem.s
 .PHONY: ct clean
 
 ct:
+	$(JASMINCT) gen_matrix.jazz
 	$(JASMINCT) --infer jkem.jazz
 
 sct:

--- a/code/jasmin/768/avx2/gen_matrix.jazz
+++ b/code/jasmin/768/avx2/gen_matrix.jazz
@@ -43,10 +43,10 @@ fn _gen_matrix_avx2_nounpack
 }
 
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_gen_matrix(
-    reg mut ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] matrix, 
-    reg const ptr u8[32] rho, 
-    #spill_to_mmx reg u64 transposed
-) -> reg ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] {
+    #secret reg mut ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] matrix,
+    #secret reg const ptr u8[32] rho,
+    #public #spill_to_mmx reg u64 transposed
+) -> #secret reg ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] {
    transposed &= 1;
    matrix = _gen_matrix_avx2_nounpack(matrix,rho,transposed);
    return matrix;

--- a/code/jasmin/common/avx2/gen_matrix.jinc
+++ b/code/jasmin/common/avx2/gen_matrix.jinc
@@ -123,6 +123,7 @@ inline fn __gen_matrix_buf_rejection_filter48
   g0 = #VPACKSS_16u16(g0, g1);
 
   // from Intel intrinsics: "Create mask from the most significant bit of each 8-bit element in a, and store the result in dst."
+  #declassify
   good = #VPMOVMSKB_u256u64(g0);
 
   good = #protect(good, ms);
@@ -268,6 +269,7 @@ inline fn __gen_matrix_buf_rejection_filter24
   g0 = #VPCMPGT_16u16(bounds, f0);
   g1 = #set0_256();
   g0 = #VPACKSS_16u16(g0, g1);
+  #declassify
   good = #VPMOVMSKB_u256u64(g0);
 
   good = #protect(good, ms);


### PR DESCRIPTION
In the rejection-sampling loop, the number of good (accepted) values is declassified.