### PR TITLE
gen-matrix: simpler loop structure and make SCT

### DIFF
--- a/code/jasmin/1024/avx2/Makefile
+++ b/code/jasmin/1024/avx2/Makefile
@@ -46,6 +46,7 @@ ct:
 	$(JASMINCT) --infer jkem.jazz
 
 sct:
+	$(JASMINCT) --sct --slice jade_kem_mlkem_mlkem1024_amd64_avx2_gen_matrix gen_matrix.jazz
 	$(JASMINCT) --sct jkem.jazz
 
 clean:

--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -9730,6 +9730,7 @@ module M(SC:Syscall_t) = {
         buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
         saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
         buf_offset <- saved_buf_offset;
+        buf_offset <- (protect_64 buf_offset ms);
       } else {
         ms <- (update_msf (! condition_loop) ms);
         buf_offset <- (W64.of_int (3 * 168));
@@ -9739,6 +9740,7 @@ module M(SC:Syscall_t) = {
     }
     ms <- (update_msf (! condition_loop) ms);
     buf_offset <- saved_buf_offset;
+    buf_offset <- (protect_64 buf_offset ms);
     condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
@@ -9750,6 +9752,7 @@ module M(SC:Syscall_t) = {
         counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
         ms);
         (* Erased call to unspill *)
+        buf_offset <- (protect_64 buf_offset ms);
         buf_offset <- (buf_offset + (W64.of_int 24));
       } else {
         ms <- (update_msf (! condition_loop) ms);

--- a/code/jasmin/1024/avx2/gen_matrix.jazz
+++ b/code/jasmin/1024/avx2/gen_matrix.jazz
@@ -33,11 +33,15 @@ fn _gen_matrix_avx2_nounpack
   return matrix;
 }
 
+#[sct="
+{ ptr: transient, val: secret } × { ptr: transient, val: secret } × transient → { ptr: public, val: secret }
+"]
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_gen_matrix(
     #secret reg mut ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] matrix,
     #secret reg const ptr u8[32] rho,
     #public #spill_to_mmx reg u64 transposed
 ) -> #secret reg ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] {
+   _ = #init_msf();
    transposed &= 1;
    matrix = _gen_matrix_avx2_nounpack(matrix,rho,transposed);
    return matrix;

--- a/code/jasmin/1024/avx2/gen_matrix.s
+++ b/code/jasmin/1024/avx2/gen_matrix.s
@@ -14,6 +14,8 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_gen_matrix:
 	movq	%r13, 24(%rsp)
 	movq	%r14, 32(%rsp)
 	movq	%rax, 40(%rsp)
+	lfence
+	movq	$0, %rax
 	andq	$1, %rdx
 	leaq	-2168(%rsp), %rsp
 	call	L_gen_matrix_avx2_nounpack$1
@@ -184,28 +186,30 @@ L_gen_matrix_buf_rejection$24:
 	movq	%rbp, %rbx
 	addq	$48, 8(%rsp)
 	movq	8(%rsp), %r12
+	orq 	%r10, %r12
 L_gen_matrix_buf_rejection$25:
 L_gen_matrix_buf_rejection$22:
 	cmpq	$457, %r12
 	jb  	L_gen_matrix_buf_rejection$23
 	movq	$-1, %rbp
 	cmovb	%rbp, %r10
-	movq	8(%rsp), %r12
+	movq	8(%rsp), %rbp
+	orq 	%r10, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r10
+	movq	$-1, %r12
+	cmovnb	%r12, %r10
 	cmpq	$256, %rbx
 	jb  	L_gen_matrix_buf_rejection$4
 	movq	$-1, %rbp
 	cmovb	%rbp, %r10
-	movq	$504, %r12
+	movq	$504, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$4:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r10
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%r9,%r12), %ymm4
+	movq	$-1, %r12
+	cmovnb	%r12, %r10
+	movq	%rbp, 8(%rsp)
+	vpermq	$148, (%r9,%rbp), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -322,11 +326,12 @@ L_gen_matrix_buf_rejection$6:
 	vmovdqu	%xmm4, (%r8,%rbp,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %r12
-	addq	$24, %r12
+	movq	8(%rsp), %rbp
+	orq 	%r10, %rbp
+	addq	$24, %rbp
 L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r12
+	cmpq	$481, %rbp
 	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_shake128x4_squeeze3blocks$1:

--- a/code/jasmin/1024/avx2/gen_matrix.s
+++ b/code/jasmin/1024/avx2/gen_matrix.s
@@ -117,14 +117,23 @@ L_gen_matrix_buf_rejection$1:
 	vmovdqu	glob_data + 0(%rip), %ymm2
 	vmovdqu	glob_data + 64(%rip), %ymm3
 	leaq	glob_data + 640(%rip), %r11
-	movq	%rcx, %rbp
-	jmp 	L_gen_matrix_buf_rejection$20
-L_gen_matrix_buf_rejection$21:
-	movq	$-1, %r12
-	cmove	%r12, %r10
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%r9,%rbp), %ymm4
-	vpermq	$148, 24(%r9,%rbp), %ymm5
+	movq	%rcx, 8(%rsp)
+	movq	%rcx, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$23:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	cmpq	$225, %rbx
+	jb  	L_gen_matrix_buf_rejection$24
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$24:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	vpermq	$148, (%r9,%r12), %ymm4
+	vpermq	$148, 24(%r9,%r12), %ymm5
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpshufb	%ymm0, %ymm5, %ymm5
 	vpsrlw	$4, %ymm4, %ymm6
@@ -173,23 +182,30 @@ L_gen_matrix_buf_rejection$21:
 	vmovdqu	%xmm5, (%r8,%r13,2)
 	vextracti128	$1, %ymm5, (%r8,%r14,2)
 	movq	%rbp, %rbx
-	movq	8(%rsp), %rbp
-	addq	$48, %rbp
-L_gen_matrix_buf_rejection$20:
-	cmpq	$457, %rbp
-	setb	%r12b
-	cmpq	$225, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$21
-	movq	$-1, %r12
-	cmovne	%r12, %r10
+	addq	$48, 8(%rsp)
+	movq	8(%rsp), %r12
+L_gen_matrix_buf_rejection$25:
+L_gen_matrix_buf_rejection$22:
+	cmpq	$457, %r12
+	jb  	L_gen_matrix_buf_rejection$23
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	8(%rsp), %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r12
-	cmove	%r12, %r10
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%r9,%rbp), %ymm4
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	cmpq	$256, %rbx
+	jb  	L_gen_matrix_buf_rejection$4
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$2
+L_gen_matrix_buf_rejection$4:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	movq	%r12, 8(%rsp)
+	vpermq	$148, (%r9,%r12), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -215,11 +231,23 @@ L_gen_matrix_buf_rejection$3:
 	vpshufb	%ymm5, %ymm4, %ymm4
 	vmovdqu	%xmm4, %xmm5
 	cmpq	$248, %rbx
-	jbe 	L_gen_matrix_buf_rejection$12
+	jbe 	L_gen_matrix_buf_rejection$14
 	movq	$-1, %r13
 	cmovbe	%r13, %r10
 	movq	%xmm5, %r13
 	cmpq	$252, %rbx
+	jbe 	L_gen_matrix_buf_rejection$20
+	movq	$-1, %r14
+	cmovbe	%r14, %r10
+	jmp 	L_gen_matrix_buf_rejection$21
+L_gen_matrix_buf_rejection$20:
+	movq	$-1, %r14
+	cmovnbe	%r14, %r10
+	movq	%r13, (%r8,%rbx,2)
+	vpextrq	$1, %xmm5, %r13
+	addq	$4, %rbx
+L_gen_matrix_buf_rejection$21:
+	cmpq	$254, %rbx
 	jbe 	L_gen_matrix_buf_rejection$18
 	movq	$-1, %r14
 	cmovbe	%r14, %r10
@@ -227,45 +255,45 @@ L_gen_matrix_buf_rejection$3:
 L_gen_matrix_buf_rejection$18:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r10
-	movq	%r13, (%r8,%rbx,2)
-	vpextrq	$1, %xmm5, %r13
-	addq	$4, %rbx
-L_gen_matrix_buf_rejection$19:
-	cmpq	$254, %rbx
-	jbe 	L_gen_matrix_buf_rejection$16
-	movq	$-1, %r14
-	cmovbe	%r14, %r10
-	jmp 	L_gen_matrix_buf_rejection$17
-L_gen_matrix_buf_rejection$16:
-	movq	$-1, %r14
-	cmovnbe	%r14, %r10
 	movl	%r13d, (%r8,%rbx,2)
 	shrq	$32, %r13
 	addq	$2, %rbx
-L_gen_matrix_buf_rejection$17:
+L_gen_matrix_buf_rejection$19:
 	cmpq	$255, %rbx
-	jbe 	L_gen_matrix_buf_rejection$14
+	jbe 	L_gen_matrix_buf_rejection$16
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$14:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$16:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r10
 	movw	%r13w, (%r8,%rbx,2)
-L_gen_matrix_buf_rejection$15:
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$12:
+L_gen_matrix_buf_rejection$17:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$14:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
 	vmovdqu	%xmm5, (%r8,%rbx,2)
-L_gen_matrix_buf_rejection$13:
+L_gen_matrix_buf_rejection$15:
 	vextracti128	$1, %ymm4, %xmm4
 	cmpq	$248, %rbp
-	jbe 	L_gen_matrix_buf_rejection$4
+	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
 	movq	%xmm4, %rbx
 	cmpq	$252, %rbp
+	jbe 	L_gen_matrix_buf_rejection$12
+	movq	$-1, %r13
+	cmovbe	%r13, %r10
+	jmp 	L_gen_matrix_buf_rejection$13
+L_gen_matrix_buf_rejection$12:
+	movq	$-1, %r13
+	cmovnbe	%r13, %r10
+	movq	%rbx, (%r8,%rbp,2)
+	vpextrq	$1, %xmm4, %rbx
+	addq	$4, %rbp
+L_gen_matrix_buf_rejection$13:
+	cmpq	$254, %rbp
 	jbe 	L_gen_matrix_buf_rejection$10
 	movq	$-1, %r13
 	cmovbe	%r13, %r10
@@ -273,48 +301,33 @@ L_gen_matrix_buf_rejection$13:
 L_gen_matrix_buf_rejection$10:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
-	movq	%rbx, (%r8,%rbp,2)
-	vpextrq	$1, %xmm4, %rbx
-	addq	$4, %rbp
-L_gen_matrix_buf_rejection$11:
-	cmpq	$254, %rbp
-	jbe 	L_gen_matrix_buf_rejection$8
-	movq	$-1, %r13
-	cmovbe	%r13, %r10
-	jmp 	L_gen_matrix_buf_rejection$9
-L_gen_matrix_buf_rejection$8:
-	movq	$-1, %r13
-	cmovnbe	%r13, %r10
 	movl	%ebx, (%r8,%rbp,2)
 	shrq	$32, %rbx
 	addq	$2, %rbp
-L_gen_matrix_buf_rejection$9:
+L_gen_matrix_buf_rejection$11:
 	cmpq	$255, %rbp
-	jbe 	L_gen_matrix_buf_rejection$6
+	jbe 	L_gen_matrix_buf_rejection$8
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$6:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$8:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
 	movw	%bx, (%r8,%rbp,2)
-L_gen_matrix_buf_rejection$7:
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$4:
+L_gen_matrix_buf_rejection$9:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbx
 	cmovnbe	%rbx, %r10
 	vmovdqu	%xmm4, (%r8,%rbp,2)
-L_gen_matrix_buf_rejection$5:
+L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %rbp
-	addq	$24, %rbp
+	movq	8(%rsp), %r12
+	addq	$24, %r12
+L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %rbp
-	setb	%r12b
-	cmpq	$256, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$3
+	cmpq	$481, %r12
+	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_shake128x4_squeeze3blocks$1:
 	movq	%rdx, %r8

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -11249,28 +11249,30 @@ L_gen_matrix_buf_rejection$24:
 	movq	%r12, %rbp
 	addq	$48, 8(%rsp)
 	movq	8(%rsp), %r13
+	orq 	%r11, %r13
 L_gen_matrix_buf_rejection$25:
 L_gen_matrix_buf_rejection$22:
 	cmpq	$457, %r13
 	jb  	L_gen_matrix_buf_rejection$23
 	movq	$-1, %r12
 	cmovb	%r12, %r11
-	movq	8(%rsp), %r13
+	movq	8(%rsp), %r12
+	orq 	%r11, %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r12
-	cmovnb	%r12, %r11
+	movq	$-1, %r13
+	cmovnb	%r13, %r11
 	cmpq	$256, %rbp
 	jb  	L_gen_matrix_buf_rejection$4
 	movq	$-1, %r12
 	cmovb	%r12, %r11
-	movq	$504, %r13
+	movq	$504, %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$4:
-	movq	$-1, %r12
-	cmovnb	%r12, %r11
-	movq	%r13, 8(%rsp)
-	vpermq	$148, (%r10,%r13), %ymm4
+	movq	$-1, %r13
+	cmovnb	%r13, %r11
+	movq	%r12, 8(%rsp)
+	vpermq	$148, (%r10,%r12), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -11387,11 +11389,12 @@ L_gen_matrix_buf_rejection$6:
 	vmovdqu	%xmm4, (%r9,%r12,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r13, %rbp
-	movq	8(%rsp), %r13
-	addq	$24, %r13
+	movq	8(%rsp), %r12
+	orq 	%r11, %r12
+	addq	$24, %r12
 L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r13
+	cmpq	$481, %r12
 	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_poly_decompress$1:

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -3549,17 +3549,17 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc:
 	movq	%r14, 18624(%rsp)
 	movq	%r15, 18632(%rsp)
 	movq	%rax, 18640(%rsp)
-	movq	%rdi, %r12
-	movq	%rsi, %rbx
-	movq	%rdx, %rbp
+	movq	%rdi, %rbx
+	movq	%rsi, %rbp
+	movq	%rdx, %r12
 	leaq	18560(%rsp), %rdi
 	movq	$32, %rsi
 	call	__jasmin_syscall_randombytes__
 	lfence
 	movq	$0, %rcx
-	movq	%rbp, %mm0
-	movq	%r12, %mm1
-	movq	%rbx, %mm2
+	movq	%r12, %mm0
+	movq	%rbx, %mm1
+	movq	%rbp, %mm2
 	movq	(%rax), %rcx
 	movq	%rcx, (%rsp)
 	movq	8(%rax), %rcx
@@ -7159,7 +7159,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_keypair$2:
 	movq	%rcx, (%rax)
 	addq	$8, %rax
 	movq	%rax, %mm0
-	movq	%mm2, %rbp
+	movq	%mm2, %r12
 	leaq	14912(%rsp), %rax
 	call	L_sha3_256A_M1568$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_keypair$1:
@@ -7212,7 +7212,7 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand:
 	movq	%rax, 18640(%rsp)
 	lfence
 	movq	$0, %rax
-	movq	%rdx, %rbp
+	movq	%rdx, %r12
 	movb	(%rcx), %al
 	movb	%al, 18560(%rsp)
 	movb	1(%rcx), %al
@@ -7278,7 +7278,7 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand:
 	movb	31(%rcx), %al
 	movb	%al, 18591(%rsp)
 	leaq	18560(%rsp), %rax
-	movq	%rbp, %mm0
+	movq	%r12, %mm0
 	movq	%rdi, %mm1
 	movq	%rsi, %mm2
 	movq	(%rax), %rcx
@@ -11004,7 +11004,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_keypair_derand$2:
 	movq	%rcx, (%rax)
 	addq	$8, %rax
 	movq	%rax, %mm0
-	movq	%mm2, %rbp
+	movq	%mm2, %r12
 	leaq	14912(%rsp), %rax
 	call	L_sha3_256A_M1568$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_keypair_derand$1:
@@ -11182,14 +11182,23 @@ L_gen_matrix_buf_rejection$1:
 	vmovdqu	glob_data + 0(%rip), %ymm2
 	vmovdqu	glob_data + 64(%rip), %ymm3
 	leaq	glob_data + 2912(%rip), %rbx
-	movq	%rdx, %r12
-	jmp 	L_gen_matrix_buf_rejection$20
-L_gen_matrix_buf_rejection$21:
-	movq	$-1, %r13
-	cmove	%r13, %r11
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%r10,%r12), %ymm4
-	vpermq	$148, 24(%r10,%r12), %ymm5
+	movq	%rdx, 8(%rsp)
+	movq	%rdx, %r13
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$23:
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	cmpq	$225, %rbp
+	jb  	L_gen_matrix_buf_rejection$24
+	movq	$-1, %r12
+	cmovb	%r12, %r11
+	movq	$504, %r13
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$24:
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	vpermq	$148, (%r10,%r13), %ymm4
+	vpermq	$148, 24(%r10,%r13), %ymm5
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpshufb	%ymm0, %ymm5, %ymm5
 	vpsrlw	$4, %ymm4, %ymm6
@@ -11238,23 +11247,30 @@ L_gen_matrix_buf_rejection$21:
 	vmovdqu	%xmm5, (%r9,%r14,2)
 	vextracti128	$1, %ymm5, (%r9,%r15,2)
 	movq	%r12, %rbp
-	movq	8(%rsp), %r12
-	addq	$48, %r12
-L_gen_matrix_buf_rejection$20:
-	cmpq	$457, %r12
-	setb	%r13b
-	cmpq	$225, %rbp
-	setb	%r14b
-	testb	%r14b, %r13b
-	jne 	L_gen_matrix_buf_rejection$21
-	movq	$-1, %r13
-	cmovne	%r13, %r11
+	addq	$48, 8(%rsp)
+	movq	8(%rsp), %r13
+L_gen_matrix_buf_rejection$25:
+L_gen_matrix_buf_rejection$22:
+	cmpq	$457, %r13
+	jb  	L_gen_matrix_buf_rejection$23
+	movq	$-1, %r12
+	cmovb	%r12, %r11
+	movq	8(%rsp), %r13
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r13
-	cmove	%r13, %r11
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%r10,%r12), %ymm4
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	cmpq	$256, %rbp
+	jb  	L_gen_matrix_buf_rejection$4
+	movq	$-1, %r12
+	cmovb	%r12, %r11
+	movq	$504, %r13
+	jmp 	L_gen_matrix_buf_rejection$2
+L_gen_matrix_buf_rejection$4:
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	movq	%r13, 8(%rsp)
+	vpermq	$148, (%r10,%r13), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -11280,11 +11296,23 @@ L_gen_matrix_buf_rejection$3:
 	vpshufb	%ymm5, %ymm4, %ymm4
 	vmovdqu	%xmm4, %xmm5
 	cmpq	$248, %rbp
-	jbe 	L_gen_matrix_buf_rejection$12
+	jbe 	L_gen_matrix_buf_rejection$14
 	movq	$-1, %r14
 	cmovbe	%r14, %r11
 	movq	%xmm5, %r14
 	cmpq	$252, %rbp
+	jbe 	L_gen_matrix_buf_rejection$20
+	movq	$-1, %r15
+	cmovbe	%r15, %r11
+	jmp 	L_gen_matrix_buf_rejection$21
+L_gen_matrix_buf_rejection$20:
+	movq	$-1, %r15
+	cmovnbe	%r15, %r11
+	movq	%r14, (%r9,%rbp,2)
+	vpextrq	$1, %xmm5, %r14
+	addq	$4, %rbp
+L_gen_matrix_buf_rejection$21:
+	cmpq	$254, %rbp
 	jbe 	L_gen_matrix_buf_rejection$18
 	movq	$-1, %r15
 	cmovbe	%r15, %r11
@@ -11292,45 +11320,45 @@ L_gen_matrix_buf_rejection$3:
 L_gen_matrix_buf_rejection$18:
 	movq	$-1, %r15
 	cmovnbe	%r15, %r11
-	movq	%r14, (%r9,%rbp,2)
-	vpextrq	$1, %xmm5, %r14
-	addq	$4, %rbp
-L_gen_matrix_buf_rejection$19:
-	cmpq	$254, %rbp
-	jbe 	L_gen_matrix_buf_rejection$16
-	movq	$-1, %r15
-	cmovbe	%r15, %r11
-	jmp 	L_gen_matrix_buf_rejection$17
-L_gen_matrix_buf_rejection$16:
-	movq	$-1, %r15
-	cmovnbe	%r15, %r11
 	movl	%r14d, (%r9,%rbp,2)
 	shrq	$32, %r14
 	addq	$2, %rbp
-L_gen_matrix_buf_rejection$17:
+L_gen_matrix_buf_rejection$19:
 	cmpq	$255, %rbp
-	jbe 	L_gen_matrix_buf_rejection$14
+	jbe 	L_gen_matrix_buf_rejection$16
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$14:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$16:
 	movq	$-1, %r15
 	cmovnbe	%r15, %r11
 	movw	%r14w, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$15:
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$12:
+L_gen_matrix_buf_rejection$17:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$14:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
 	vmovdqu	%xmm5, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$13:
+L_gen_matrix_buf_rejection$15:
 	vextracti128	$1, %ymm4, %xmm4
 	cmpq	$248, %r12
-	jbe 	L_gen_matrix_buf_rejection$4
+	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
 	movq	%xmm4, %rbp
 	cmpq	$252, %r12
+	jbe 	L_gen_matrix_buf_rejection$12
+	movq	$-1, %r14
+	cmovbe	%r14, %r11
+	jmp 	L_gen_matrix_buf_rejection$13
+L_gen_matrix_buf_rejection$12:
+	movq	$-1, %r14
+	cmovnbe	%r14, %r11
+	movq	%rbp, (%r9,%r12,2)
+	vpextrq	$1, %xmm4, %rbp
+	addq	$4, %r12
+L_gen_matrix_buf_rejection$13:
+	cmpq	$254, %r12
 	jbe 	L_gen_matrix_buf_rejection$10
 	movq	$-1, %r14
 	cmovbe	%r14, %r11
@@ -11338,48 +11366,33 @@ L_gen_matrix_buf_rejection$13:
 L_gen_matrix_buf_rejection$10:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
-	movq	%rbp, (%r9,%r12,2)
-	vpextrq	$1, %xmm4, %rbp
-	addq	$4, %r12
-L_gen_matrix_buf_rejection$11:
-	cmpq	$254, %r12
-	jbe 	L_gen_matrix_buf_rejection$8
-	movq	$-1, %r14
-	cmovbe	%r14, %r11
-	jmp 	L_gen_matrix_buf_rejection$9
-L_gen_matrix_buf_rejection$8:
-	movq	$-1, %r14
-	cmovnbe	%r14, %r11
 	movl	%ebp, (%r9,%r12,2)
 	shrq	$32, %rbp
 	addq	$2, %r12
-L_gen_matrix_buf_rejection$9:
+L_gen_matrix_buf_rejection$11:
 	cmpq	$255, %r12
-	jbe 	L_gen_matrix_buf_rejection$6
+	jbe 	L_gen_matrix_buf_rejection$8
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$6:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$8:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
 	movw	%bp, (%r9,%r12,2)
-L_gen_matrix_buf_rejection$7:
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$4:
+L_gen_matrix_buf_rejection$9:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
 	vmovdqu	%xmm4, (%r9,%r12,2)
-L_gen_matrix_buf_rejection$5:
+L_gen_matrix_buf_rejection$7:
 	movq	%r13, %rbp
-	movq	8(%rsp), %r12
-	addq	$24, %r12
+	movq	8(%rsp), %r13
+	addq	$24, %r13
+L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r12
-	setb	%r13b
-	cmpq	$256, %rbp
-	setb	%r14b
-	testb	%r14b, %r13b
-	jne 	L_gen_matrix_buf_rejection$3
+	cmpq	$481, %r13
+	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_poly_decompress$1:
 	leaq	glob_data + 1184(%rip), %rdi
@@ -15660,28 +15673,28 @@ L_sha3_256A_M1568$1:
 	movq	$0, %rcx
 	jmp 	L_sha3_256A_M1568$3
 L_sha3_256A_M1568$4:
-	vpbroadcastq	(%rbp), %ymm7
-	addq	$8, %rbp
+	vpbroadcastq	(%r12), %ymm7
+	addq	$8, %r12
 	vpxor	%ymm7, %ymm0, %ymm0
-	vmovdqu	(%rbp), %ymm7
-	addq	$32, %rbp
+	vmovdqu	(%r12), %ymm7
+	addq	$32, %r12
 	vpxor	%ymm7, %ymm1, %ymm1
-	movq	(%rbp), %rdx
-	addq	$8, %rbp
+	movq	(%r12), %rdx
+	addq	$8, %r12
 	movq	%rdx, %xmm9
-	vmovdqu	(%rbp), %ymm7
-	addq	$32, %rbp
-	movq	(%rbp), %rdx
-	addq	$8, %rbp
+	vmovdqu	(%r12), %ymm7
+	addq	$32, %r12
+	movq	(%r12), %rdx
+	addq	$8, %r12
 	movq	%rdx, %xmm10
-	vmovdqu	(%rbp), %ymm8
-	addq	$32, %rbp
-	movq	(%rbp), %rdx
-	addq	$8, %rbp
+	vmovdqu	(%r12), %ymm8
+	addq	$32, %r12
+	movq	(%r12), %rdx
+	addq	$8, %r12
 	vpinsrq	$1, %rdx, %xmm9, %xmm11
 	vpxor	%xmm9, %xmm9, %xmm9
-	vmovq	(%rbp), %xmm12
-	addq	$8, %rbp
+	vmovq	(%r12), %xmm12
+	addq	$8, %r12
 	movq	$0, %rdx
 	vpinsrq	$1, %rdx, %xmm12, %xmm12
 	vinserti128	$1, %xmm9, %ymm12, %ymm9
@@ -15708,18 +15721,18 @@ L_sha3_256A_M1568$5:
 L_sha3_256A_M1568$3:
 	cmpq	$11, %rcx
 	jb  	L_sha3_256A_M1568$4
-	vpbroadcastq	(%rbp), %ymm7
-	addq	$8, %rbp
+	vpbroadcastq	(%r12), %ymm7
+	addq	$8, %r12
 	vpxor	%ymm7, %ymm0, %ymm0
-	vmovdqu	(%rbp), %ymm7
-	addq	$32, %rbp
+	vmovdqu	(%r12), %ymm7
+	addq	$32, %r12
 	vpxor	%ymm7, %ymm1, %ymm1
-	movq	(%rbp), %rcx
-	addq	$8, %rbp
+	movq	(%r12), %rcx
+	addq	$8, %r12
 	movq	%rcx, %xmm9
-	vmovdqu	(%rbp), %xmm7
-	addq	$16, %rbp
-	vmovq	(%rbp), %xmm8
+	vmovdqu	(%r12), %xmm7
+	addq	$16, %r12
+	vmovq	(%r12), %xmm8
 	movq	$6, %rcx
 	vpinsrq	$1, %rcx, %xmm8, %xmm8
 	vinserti128	$1, %xmm8, %ymm7, %ymm7

--- a/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
+++ b/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
@@ -9383,6 +9383,7 @@ module M = {
         buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
         saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
         buf_offset <- saved_buf_offset;
+        buf_offset <- (protect_64 buf_offset ms);
       } else {
         ms <- (update_msf (! condition_loop) ms);
         buf_offset <- (W64.of_int (3 * 168));
@@ -9392,6 +9393,7 @@ module M = {
     }
     ms <- (update_msf (! condition_loop) ms);
     buf_offset <- saved_buf_offset;
+    buf_offset <- (protect_64 buf_offset ms);
     condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
@@ -9403,6 +9405,7 @@ module M = {
         counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
         ms);
         (* Erased call to unspill *)
+        buf_offset <- (protect_64 buf_offset ms);
         buf_offset <- (buf_offset + (W64.of_int 24));
       } else {
         ms <- (update_msf (! condition_loop) ms);

--- a/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
+++ b/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
@@ -9100,29 +9100,6 @@ module M = {
     }
     return rp;
   }
-  proc comp_u64_l_int_and_u64_l_int (a:W64.t, b:int, c:W64.t, d:int) : bool = {
-    var c3:bool;
-    var _of_:bool;
-    var _cf_:bool;
-    var _sf_:bool;
-    var _zf_:bool;
-    var c1:bool;
-    var bc1:W8.t;
-    var c2:bool;
-    var bc2:W8.t;
-    var  _0:bool;
-    var  _1:bool;
-    var  _2:bool;
-    (_of_, _cf_, _sf_,  _0, _zf_) <- (CMP_64 a (W64.of_int b));
-    c1 <- (_uLT _of_ _cf_ _sf_ _zf_);
-    bc1 <- (SETcc c1);
-    (_of_, _cf_, _sf_,  _1, _zf_) <- (CMP_64 c (W64.of_int d));
-    c2 <- (_uLT _of_ _cf_ _sf_ _zf_);
-    bc2 <- (SETcc c2);
-    (_of_, _cf_, _sf_,  _2, _zf_) <- (TEST_8 bc1 bc2);
-    c3 <- (_NEQ _of_ _cf_ _sf_ _zf_);
-    return c3;
-  }
   proc __gen_matrix_buf_rejection_filter48 (pol:W16.t Array256.t,
                                             counter:W64.t,
                                             buf:W8.t Array536.t,
@@ -9384,6 +9361,7 @@ module M = {
     var bounds:W256.t;
     var ones:W256.t;
     var sst:W8.t Array2048.t;
+    var saved_buf_offset:W64.t;
     var condition_loop:bool;
     sst <- witness;
     ms <- (init_msf);
@@ -9393,32 +9371,45 @@ module M = {
     bounds <- sample_q;
     ones <- sample_ones;
     sst <- sample_shuffle_table;
+    saved_buf_offset <- buf_offset;
     buf_offset <- buf_offset;
-    condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-    (((3 * 168) - 48) + 1), counter, ((256 - 32) + 1));
+    condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 48) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
-      (* Erased call to spill *)
-      (pol, counter) <@ __gen_matrix_buf_rejection_filter48 (pol, counter,
-      buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
-      (* Erased call to unspill *)
-      buf_offset <- (buf_offset + (W64.of_int 48));
-      condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-      (((3 * 168) - 48) + 1), counter, ((256 - 32) + 1));
+      condition_loop <- (counter \ult (W64.of_int ((256 - 32) + 1)));
+      if (condition_loop) {
+        ms <- (update_msf condition_loop ms);
+        (pol, counter) <@ __gen_matrix_buf_rejection_filter48 (pol, counter,
+        buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
+        saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
+        buf_offset <- saved_buf_offset;
+      } else {
+        ms <- (update_msf (! condition_loop) ms);
+        buf_offset <- (W64.of_int (3 * 168));
+      }
+      condition_loop <-
+      (buf_offset \ult (W64.of_int (((3 * 168) - 48) + 1)));
     }
     ms <- (update_msf (! condition_loop) ms);
-    condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-    (((3 * 168) - 24) + 1), counter, 256);
+    buf_offset <- saved_buf_offset;
+    condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
-      (* Erased call to spill *)
-      (pol, counter, ms) <@ __gen_matrix_buf_rejection_filter24 (pol,
-      counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
-      ms);
-      (* Erased call to unspill *)
-      buf_offset <- (buf_offset + (W64.of_int 24));
-      condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-      (((3 * 168) - 24) + 1), counter, 256);
+      condition_loop <- (counter \ult (W64.of_int 256));
+      if (condition_loop) {
+        ms <- (update_msf condition_loop ms);
+        (* Erased call to spill *)
+        (pol, counter, ms) <@ __gen_matrix_buf_rejection_filter24 (pol,
+        counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
+        ms);
+        (* Erased call to unspill *)
+        buf_offset <- (buf_offset + (W64.of_int 24));
+      } else {
+        ms <- (update_msf (! condition_loop) ms);
+        buf_offset <- (W64.of_int (3 * 168));
+      }
+      condition_loop <-
+      (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     }
     return (pol, counter);
   }

--- a/code/jasmin/1024/avx2_stack/jkem.s
+++ b/code/jasmin/1024/avx2_stack/jkem.s
@@ -12884,28 +12884,30 @@ L_gen_matrix_buf_rejection$24:
 	movq	%r12, %rbp
 	addq	$48, 8(%rsp)
 	movq	8(%rsp), %r13
+	orq 	%r11, %r13
 L_gen_matrix_buf_rejection$25:
 L_gen_matrix_buf_rejection$22:
 	cmpq	$457, %r13
 	jb  	L_gen_matrix_buf_rejection$23
 	movq	$-1, %r12
 	cmovb	%r12, %r11
-	movq	8(%rsp), %r13
+	movq	8(%rsp), %r12
+	orq 	%r11, %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r12
-	cmovnb	%r12, %r11
+	movq	$-1, %r13
+	cmovnb	%r13, %r11
 	cmpq	$256, %rbp
 	jb  	L_gen_matrix_buf_rejection$4
 	movq	$-1, %r12
 	cmovb	%r12, %r11
-	movq	$504, %r13
+	movq	$504, %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$4:
-	movq	$-1, %r12
-	cmovnb	%r12, %r11
-	movq	%r13, 8(%rsp)
-	vpermq	$148, (%r10,%r13), %ymm4
+	movq	$-1, %r13
+	cmovnb	%r13, %r11
+	movq	%r12, 8(%rsp)
+	vpermq	$148, (%r10,%r12), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -13022,11 +13024,12 @@ L_gen_matrix_buf_rejection$6:
 	vmovdqu	%xmm4, (%r9,%r12,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r13, %rbp
-	movq	8(%rsp), %r13
-	addq	$24, %r13
+	movq	8(%rsp), %r12
+	orq 	%r11, %r12
+	addq	$24, %r12
 L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r13
+	cmpq	$481, %r12
 	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_i_poly_decompress$1:

--- a/code/jasmin/1024/avx2_stack/jkem.s
+++ b/code/jasmin/1024/avx2_stack/jkem.s
@@ -12817,14 +12817,23 @@ L_gen_matrix_buf_rejection$1:
 	vmovdqu	glob_data + 0(%rip), %ymm2
 	vmovdqu	glob_data + 64(%rip), %ymm3
 	leaq	glob_data + 2912(%rip), %rbx
-	movq	%rdx, %r12
-	jmp 	L_gen_matrix_buf_rejection$20
-L_gen_matrix_buf_rejection$21:
-	movq	$-1, %r13
-	cmove	%r13, %r11
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%r10,%r12), %ymm4
-	vpermq	$148, 24(%r10,%r12), %ymm5
+	movq	%rdx, 8(%rsp)
+	movq	%rdx, %r13
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$23:
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	cmpq	$225, %rbp
+	jb  	L_gen_matrix_buf_rejection$24
+	movq	$-1, %r12
+	cmovb	%r12, %r11
+	movq	$504, %r13
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$24:
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	vpermq	$148, (%r10,%r13), %ymm4
+	vpermq	$148, 24(%r10,%r13), %ymm5
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpshufb	%ymm0, %ymm5, %ymm5
 	vpsrlw	$4, %ymm4, %ymm6
@@ -12873,23 +12882,30 @@ L_gen_matrix_buf_rejection$21:
 	vmovdqu	%xmm5, (%r9,%r14,2)
 	vextracti128	$1, %ymm5, (%r9,%r15,2)
 	movq	%r12, %rbp
-	movq	8(%rsp), %r12
-	addq	$48, %r12
-L_gen_matrix_buf_rejection$20:
-	cmpq	$457, %r12
-	setb	%r13b
-	cmpq	$225, %rbp
-	setb	%r14b
-	testb	%r14b, %r13b
-	jne 	L_gen_matrix_buf_rejection$21
-	movq	$-1, %r13
-	cmovne	%r13, %r11
+	addq	$48, 8(%rsp)
+	movq	8(%rsp), %r13
+L_gen_matrix_buf_rejection$25:
+L_gen_matrix_buf_rejection$22:
+	cmpq	$457, %r13
+	jb  	L_gen_matrix_buf_rejection$23
+	movq	$-1, %r12
+	cmovb	%r12, %r11
+	movq	8(%rsp), %r13
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r13
-	cmove	%r13, %r11
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%r10,%r12), %ymm4
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	cmpq	$256, %rbp
+	jb  	L_gen_matrix_buf_rejection$4
+	movq	$-1, %r12
+	cmovb	%r12, %r11
+	movq	$504, %r13
+	jmp 	L_gen_matrix_buf_rejection$2
+L_gen_matrix_buf_rejection$4:
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	movq	%r13, 8(%rsp)
+	vpermq	$148, (%r10,%r13), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -12915,11 +12931,23 @@ L_gen_matrix_buf_rejection$3:
 	vpshufb	%ymm5, %ymm4, %ymm4
 	vmovdqu	%xmm4, %xmm5
 	cmpq	$248, %rbp
-	jbe 	L_gen_matrix_buf_rejection$12
+	jbe 	L_gen_matrix_buf_rejection$14
 	movq	$-1, %r14
 	cmovbe	%r14, %r11
 	movq	%xmm5, %r14
 	cmpq	$252, %rbp
+	jbe 	L_gen_matrix_buf_rejection$20
+	movq	$-1, %r15
+	cmovbe	%r15, %r11
+	jmp 	L_gen_matrix_buf_rejection$21
+L_gen_matrix_buf_rejection$20:
+	movq	$-1, %r15
+	cmovnbe	%r15, %r11
+	movq	%r14, (%r9,%rbp,2)
+	vpextrq	$1, %xmm5, %r14
+	addq	$4, %rbp
+L_gen_matrix_buf_rejection$21:
+	cmpq	$254, %rbp
 	jbe 	L_gen_matrix_buf_rejection$18
 	movq	$-1, %r15
 	cmovbe	%r15, %r11
@@ -12927,45 +12955,45 @@ L_gen_matrix_buf_rejection$3:
 L_gen_matrix_buf_rejection$18:
 	movq	$-1, %r15
 	cmovnbe	%r15, %r11
-	movq	%r14, (%r9,%rbp,2)
-	vpextrq	$1, %xmm5, %r14
-	addq	$4, %rbp
-L_gen_matrix_buf_rejection$19:
-	cmpq	$254, %rbp
-	jbe 	L_gen_matrix_buf_rejection$16
-	movq	$-1, %r15
-	cmovbe	%r15, %r11
-	jmp 	L_gen_matrix_buf_rejection$17
-L_gen_matrix_buf_rejection$16:
-	movq	$-1, %r15
-	cmovnbe	%r15, %r11
 	movl	%r14d, (%r9,%rbp,2)
 	shrq	$32, %r14
 	addq	$2, %rbp
-L_gen_matrix_buf_rejection$17:
+L_gen_matrix_buf_rejection$19:
 	cmpq	$255, %rbp
-	jbe 	L_gen_matrix_buf_rejection$14
+	jbe 	L_gen_matrix_buf_rejection$16
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$14:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$16:
 	movq	$-1, %r15
 	cmovnbe	%r15, %r11
 	movw	%r14w, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$15:
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$12:
+L_gen_matrix_buf_rejection$17:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$14:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
 	vmovdqu	%xmm5, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$13:
+L_gen_matrix_buf_rejection$15:
 	vextracti128	$1, %ymm4, %xmm4
 	cmpq	$248, %r12
-	jbe 	L_gen_matrix_buf_rejection$4
+	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
 	movq	%xmm4, %rbp
 	cmpq	$252, %r12
+	jbe 	L_gen_matrix_buf_rejection$12
+	movq	$-1, %r14
+	cmovbe	%r14, %r11
+	jmp 	L_gen_matrix_buf_rejection$13
+L_gen_matrix_buf_rejection$12:
+	movq	$-1, %r14
+	cmovnbe	%r14, %r11
+	movq	%rbp, (%r9,%r12,2)
+	vpextrq	$1, %xmm4, %rbp
+	addq	$4, %r12
+L_gen_matrix_buf_rejection$13:
+	cmpq	$254, %r12
 	jbe 	L_gen_matrix_buf_rejection$10
 	movq	$-1, %r14
 	cmovbe	%r14, %r11
@@ -12973,48 +13001,33 @@ L_gen_matrix_buf_rejection$13:
 L_gen_matrix_buf_rejection$10:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
-	movq	%rbp, (%r9,%r12,2)
-	vpextrq	$1, %xmm4, %rbp
-	addq	$4, %r12
-L_gen_matrix_buf_rejection$11:
-	cmpq	$254, %r12
-	jbe 	L_gen_matrix_buf_rejection$8
-	movq	$-1, %r14
-	cmovbe	%r14, %r11
-	jmp 	L_gen_matrix_buf_rejection$9
-L_gen_matrix_buf_rejection$8:
-	movq	$-1, %r14
-	cmovnbe	%r14, %r11
 	movl	%ebp, (%r9,%r12,2)
 	shrq	$32, %rbp
 	addq	$2, %r12
-L_gen_matrix_buf_rejection$9:
+L_gen_matrix_buf_rejection$11:
 	cmpq	$255, %r12
-	jbe 	L_gen_matrix_buf_rejection$6
+	jbe 	L_gen_matrix_buf_rejection$8
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$6:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$8:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
 	movw	%bp, (%r9,%r12,2)
-L_gen_matrix_buf_rejection$7:
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$4:
+L_gen_matrix_buf_rejection$9:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
 	vmovdqu	%xmm4, (%r9,%r12,2)
-L_gen_matrix_buf_rejection$5:
+L_gen_matrix_buf_rejection$7:
 	movq	%r13, %rbp
-	movq	8(%rsp), %r12
-	addq	$24, %r12
+	movq	8(%rsp), %r13
+	addq	$24, %r13
+L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r12
-	setb	%r13b
-	cmpq	$256, %rbp
-	setb	%r14b
-	testb	%r14b, %r13b
-	jne 	L_gen_matrix_buf_rejection$3
+	cmpq	$481, %r13
+	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_i_poly_decompress$1:
 	leaq	glob_data + 1184(%rip), %rdi

--- a/code/jasmin/768/avx2/Makefile
+++ b/code/jasmin/768/avx2/Makefile
@@ -46,6 +46,7 @@ ct:
 	$(JASMINCT) --infer jkem.jazz
 
 sct:
+	$(JASMINCT) --sct --slice jade_kem_mlkem_mlkem768_amd64_avx2_gen_matrix gen_matrix.jazz
 	$(JASMINCT) --sct jkem.jazz
 
 clean:

--- a/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
+++ b/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
@@ -9051,29 +9051,6 @@ module M(SC:Syscall_t) = {
     }
     return rp;
   }
-  proc comp_u64_l_int_and_u64_l_int (a:W64.t, b:int, c:W64.t, d:int) : bool = {
-    var c3:bool;
-    var _of_:bool;
-    var _cf_:bool;
-    var _sf_:bool;
-    var _zf_:bool;
-    var c1:bool;
-    var bc1:W8.t;
-    var c2:bool;
-    var bc2:W8.t;
-    var  _0:bool;
-    var  _1:bool;
-    var  _2:bool;
-    (_of_, _cf_, _sf_,  _0, _zf_) <- (CMP_64 a (W64.of_int b));
-    c1 <- (_uLT _of_ _cf_ _sf_ _zf_);
-    bc1 <- (SETcc c1);
-    (_of_, _cf_, _sf_,  _1, _zf_) <- (CMP_64 c (W64.of_int d));
-    c2 <- (_uLT _of_ _cf_ _sf_ _zf_);
-    bc2 <- (SETcc c2);
-    (_of_, _cf_, _sf_,  _2, _zf_) <- (TEST_8 bc1 bc2);
-    c3 <- (_NEQ _of_ _cf_ _sf_ _zf_);
-    return c3;
-  }
   proc __gen_matrix_buf_rejection_filter48 (pol:W16.t Array256.t,
                                             counter:W64.t,
                                             buf:W8.t Array536.t,
@@ -9335,6 +9312,7 @@ module M(SC:Syscall_t) = {
     var bounds:W256.t;
     var ones:W256.t;
     var sst:W8.t Array2048.t;
+    var saved_buf_offset:W64.t;
     var condition_loop:bool;
     sst <- witness;
     ms <- (init_msf);
@@ -9344,32 +9322,45 @@ module M(SC:Syscall_t) = {
     bounds <- sample_q;
     ones <- sample_ones;
     sst <- sample_shuffle_table;
+    saved_buf_offset <- buf_offset;
     buf_offset <- buf_offset;
-    condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-    (((3 * 168) - 48) + 1), counter, ((256 - 32) + 1));
+    condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 48) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
-      (* Erased call to spill *)
-      (pol, counter) <@ __gen_matrix_buf_rejection_filter48 (pol, counter,
-      buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
-      (* Erased call to unspill *)
-      buf_offset <- (buf_offset + (W64.of_int 48));
-      condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-      (((3 * 168) - 48) + 1), counter, ((256 - 32) + 1));
+      condition_loop <- (counter \ult (W64.of_int ((256 - 32) + 1)));
+      if (condition_loop) {
+        ms <- (update_msf condition_loop ms);
+        (pol, counter) <@ __gen_matrix_buf_rejection_filter48 (pol, counter,
+        buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
+        saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
+        buf_offset <- saved_buf_offset;
+      } else {
+        ms <- (update_msf (! condition_loop) ms);
+        buf_offset <- (W64.of_int (3 * 168));
+      }
+      condition_loop <-
+      (buf_offset \ult (W64.of_int (((3 * 168) - 48) + 1)));
     }
     ms <- (update_msf (! condition_loop) ms);
-    condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-    (((3 * 168) - 24) + 1), counter, 256);
+    buf_offset <- saved_buf_offset;
+    condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
-      (* Erased call to spill *)
-      (pol, counter, ms) <@ __gen_matrix_buf_rejection_filter24 (pol,
-      counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
-      ms);
-      (* Erased call to unspill *)
-      buf_offset <- (buf_offset + (W64.of_int 24));
-      condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-      (((3 * 168) - 24) + 1), counter, 256);
+      condition_loop <- (counter \ult (W64.of_int 256));
+      if (condition_loop) {
+        ms <- (update_msf condition_loop ms);
+        (* Erased call to spill *)
+        (pol, counter, ms) <@ __gen_matrix_buf_rejection_filter24 (pol,
+        counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
+        ms);
+        (* Erased call to unspill *)
+        buf_offset <- (buf_offset + (W64.of_int 24));
+      } else {
+        ms <- (update_msf (! condition_loop) ms);
+        buf_offset <- (W64.of_int (3 * 168));
+      }
+      condition_loop <-
+      (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     }
     return (pol, counter);
   }

--- a/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
+++ b/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
@@ -9334,6 +9334,7 @@ module M(SC:Syscall_t) = {
         buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
         saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
         buf_offset <- saved_buf_offset;
+        buf_offset <- (protect_64 buf_offset ms);
       } else {
         ms <- (update_msf (! condition_loop) ms);
         buf_offset <- (W64.of_int (3 * 168));
@@ -9343,6 +9344,7 @@ module M(SC:Syscall_t) = {
     }
     ms <- (update_msf (! condition_loop) ms);
     buf_offset <- saved_buf_offset;
+    buf_offset <- (protect_64 buf_offset ms);
     condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
@@ -9354,6 +9356,7 @@ module M(SC:Syscall_t) = {
         counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
         ms);
         (* Erased call to unspill *)
+        buf_offset <- (protect_64 buf_offset ms);
         buf_offset <- (buf_offset + (W64.of_int 24));
       } else {
         ms <- (update_msf (! condition_loop) ms);

--- a/code/jasmin/768/avx2/gen_matrix.jazz
+++ b/code/jasmin/768/avx2/gen_matrix.jazz
@@ -42,11 +42,15 @@ fn _gen_matrix_avx2_nounpack
   return matrix;
 }
 
+#[sct="
+{ ptr: transient, val: secret } × { ptr: transient, val: secret } × transient → { ptr: public, val: secret }
+"]
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_gen_matrix(
     #secret reg mut ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] matrix,
     #secret reg const ptr u8[32] rho,
     #public #spill_to_mmx reg u64 transposed
 ) -> #secret reg ptr u16[MLKEM_K * MLKEM_K * MLKEM_N] {
+   _ = #init_msf();
    transposed &= 1;
    matrix = _gen_matrix_avx2_nounpack(matrix,rho,transposed);
    return matrix;

--- a/code/jasmin/768/avx2/gen_matrix.s
+++ b/code/jasmin/768/avx2/gen_matrix.s
@@ -14,6 +14,8 @@ jade_kem_mlkem_mlkem768_amd64_avx2_gen_matrix:
 	movq	%r13, 24(%rsp)
 	movq	%r14, 32(%rsp)
 	movq	%rax, 40(%rsp)
+	lfence
+	movq	$0, %rax
 	andq	$1, %rdx
 	leaq	-2200(%rsp), %rsp
 	call	L_gen_matrix_avx2_nounpack$1
@@ -183,28 +185,30 @@ L_gen_matrix_buf_rejection$24:
 	movq	%rbp, %rbx
 	addq	$48, 8(%rsp)
 	movq	8(%rsp), %r12
+	orq 	%r10, %r12
 L_gen_matrix_buf_rejection$25:
 L_gen_matrix_buf_rejection$22:
 	cmpq	$457, %r12
 	jb  	L_gen_matrix_buf_rejection$23
 	movq	$-1, %rbp
 	cmovb	%rbp, %r10
-	movq	8(%rsp), %r12
+	movq	8(%rsp), %rbp
+	orq 	%r10, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r10
+	movq	$-1, %r12
+	cmovnb	%r12, %r10
 	cmpq	$256, %rbx
 	jb  	L_gen_matrix_buf_rejection$4
 	movq	$-1, %rbp
 	cmovb	%rbp, %r10
-	movq	$504, %r12
+	movq	$504, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$4:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r10
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%rcx,%r12), %ymm4
+	movq	$-1, %r12
+	cmovnb	%r12, %r10
+	movq	%rbp, 8(%rsp)
+	vpermq	$148, (%rcx,%rbp), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -321,11 +325,12 @@ L_gen_matrix_buf_rejection$6:
 	vmovdqu	%xmm4, (%r9,%rbp,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %r12
-	addq	$24, %r12
+	movq	8(%rsp), %rbp
+	orq 	%r10, %rbp
+	addq	$24, %rbp
 L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r12
+	cmpq	$481, %rbp
 	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_shake128x4_squeeze3blocks$1:

--- a/code/jasmin/768/avx2/gen_matrix.s
+++ b/code/jasmin/768/avx2/gen_matrix.s
@@ -116,14 +116,23 @@ L_gen_matrix_buf_rejection$1:
 	vmovdqu	glob_data + 0(%rip), %ymm2
 	vmovdqu	glob_data + 64(%rip), %ymm3
 	leaq	glob_data + 608(%rip), %r11
-	movq	%r8, %rbp
-	jmp 	L_gen_matrix_buf_rejection$20
-L_gen_matrix_buf_rejection$21:
-	movq	$-1, %r12
-	cmove	%r12, %r10
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%rcx,%rbp), %ymm4
-	vpermq	$148, 24(%rcx,%rbp), %ymm5
+	movq	%r8, 8(%rsp)
+	movq	%r8, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$23:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	cmpq	$225, %rbx
+	jb  	L_gen_matrix_buf_rejection$24
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$24:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	vpermq	$148, (%rcx,%r12), %ymm4
+	vpermq	$148, 24(%rcx,%r12), %ymm5
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpshufb	%ymm0, %ymm5, %ymm5
 	vpsrlw	$4, %ymm4, %ymm6
@@ -172,23 +181,30 @@ L_gen_matrix_buf_rejection$21:
 	vmovdqu	%xmm5, (%r9,%r13,2)
 	vextracti128	$1, %ymm5, (%r9,%r14,2)
 	movq	%rbp, %rbx
-	movq	8(%rsp), %rbp
-	addq	$48, %rbp
-L_gen_matrix_buf_rejection$20:
-	cmpq	$457, %rbp
-	setb	%r12b
-	cmpq	$225, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$21
-	movq	$-1, %r12
-	cmovne	%r12, %r10
+	addq	$48, 8(%rsp)
+	movq	8(%rsp), %r12
+L_gen_matrix_buf_rejection$25:
+L_gen_matrix_buf_rejection$22:
+	cmpq	$457, %r12
+	jb  	L_gen_matrix_buf_rejection$23
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	8(%rsp), %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r12
-	cmove	%r12, %r10
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%rcx,%rbp), %ymm4
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	cmpq	$256, %rbx
+	jb  	L_gen_matrix_buf_rejection$4
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$2
+L_gen_matrix_buf_rejection$4:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	movq	%r12, 8(%rsp)
+	vpermq	$148, (%rcx,%r12), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -214,11 +230,23 @@ L_gen_matrix_buf_rejection$3:
 	vpshufb	%ymm5, %ymm4, %ymm4
 	vmovdqu	%xmm4, %xmm5
 	cmpq	$248, %rbx
-	jbe 	L_gen_matrix_buf_rejection$12
+	jbe 	L_gen_matrix_buf_rejection$14
 	movq	$-1, %r13
 	cmovbe	%r13, %r10
 	movq	%xmm5, %r13
 	cmpq	$252, %rbx
+	jbe 	L_gen_matrix_buf_rejection$20
+	movq	$-1, %r14
+	cmovbe	%r14, %r10
+	jmp 	L_gen_matrix_buf_rejection$21
+L_gen_matrix_buf_rejection$20:
+	movq	$-1, %r14
+	cmovnbe	%r14, %r10
+	movq	%r13, (%r9,%rbx,2)
+	vpextrq	$1, %xmm5, %r13
+	addq	$4, %rbx
+L_gen_matrix_buf_rejection$21:
+	cmpq	$254, %rbx
 	jbe 	L_gen_matrix_buf_rejection$18
 	movq	$-1, %r14
 	cmovbe	%r14, %r10
@@ -226,45 +254,45 @@ L_gen_matrix_buf_rejection$3:
 L_gen_matrix_buf_rejection$18:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r10
-	movq	%r13, (%r9,%rbx,2)
-	vpextrq	$1, %xmm5, %r13
-	addq	$4, %rbx
-L_gen_matrix_buf_rejection$19:
-	cmpq	$254, %rbx
-	jbe 	L_gen_matrix_buf_rejection$16
-	movq	$-1, %r14
-	cmovbe	%r14, %r10
-	jmp 	L_gen_matrix_buf_rejection$17
-L_gen_matrix_buf_rejection$16:
-	movq	$-1, %r14
-	cmovnbe	%r14, %r10
 	movl	%r13d, (%r9,%rbx,2)
 	shrq	$32, %r13
 	addq	$2, %rbx
-L_gen_matrix_buf_rejection$17:
+L_gen_matrix_buf_rejection$19:
 	cmpq	$255, %rbx
-	jbe 	L_gen_matrix_buf_rejection$14
+	jbe 	L_gen_matrix_buf_rejection$16
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$14:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$16:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r10
 	movw	%r13w, (%r9,%rbx,2)
-L_gen_matrix_buf_rejection$15:
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$12:
+L_gen_matrix_buf_rejection$17:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$14:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
 	vmovdqu	%xmm5, (%r9,%rbx,2)
-L_gen_matrix_buf_rejection$13:
+L_gen_matrix_buf_rejection$15:
 	vextracti128	$1, %ymm4, %xmm4
 	cmpq	$248, %rbp
-	jbe 	L_gen_matrix_buf_rejection$4
+	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
 	movq	%xmm4, %rbx
 	cmpq	$252, %rbp
+	jbe 	L_gen_matrix_buf_rejection$12
+	movq	$-1, %r13
+	cmovbe	%r13, %r10
+	jmp 	L_gen_matrix_buf_rejection$13
+L_gen_matrix_buf_rejection$12:
+	movq	$-1, %r13
+	cmovnbe	%r13, %r10
+	movq	%rbx, (%r9,%rbp,2)
+	vpextrq	$1, %xmm4, %rbx
+	addq	$4, %rbp
+L_gen_matrix_buf_rejection$13:
+	cmpq	$254, %rbp
 	jbe 	L_gen_matrix_buf_rejection$10
 	movq	$-1, %r13
 	cmovbe	%r13, %r10
@@ -272,48 +300,33 @@ L_gen_matrix_buf_rejection$13:
 L_gen_matrix_buf_rejection$10:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
-	movq	%rbx, (%r9,%rbp,2)
-	vpextrq	$1, %xmm4, %rbx
-	addq	$4, %rbp
-L_gen_matrix_buf_rejection$11:
-	cmpq	$254, %rbp
-	jbe 	L_gen_matrix_buf_rejection$8
-	movq	$-1, %r13
-	cmovbe	%r13, %r10
-	jmp 	L_gen_matrix_buf_rejection$9
-L_gen_matrix_buf_rejection$8:
-	movq	$-1, %r13
-	cmovnbe	%r13, %r10
 	movl	%ebx, (%r9,%rbp,2)
 	shrq	$32, %rbx
 	addq	$2, %rbp
-L_gen_matrix_buf_rejection$9:
+L_gen_matrix_buf_rejection$11:
 	cmpq	$255, %rbp
-	jbe 	L_gen_matrix_buf_rejection$6
+	jbe 	L_gen_matrix_buf_rejection$8
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$6:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$8:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
 	movw	%bx, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$7:
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$4:
+L_gen_matrix_buf_rejection$9:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbx
 	cmovnbe	%rbx, %r10
 	vmovdqu	%xmm4, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$5:
+L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %rbp
-	addq	$24, %rbp
+	movq	8(%rsp), %r12
+	addq	$24, %r12
+L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %rbp
-	setb	%r12b
-	cmpq	$256, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$3
+	cmpq	$481, %r12
+	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_shake128x4_squeeze3blocks$1:
 	movq	%rdx, %r8

--- a/code/jasmin/768/avx2/jkem.s
+++ b/code/jasmin/768/avx2/jkem.s
@@ -7963,28 +7963,30 @@ L_gen_matrix_buf_rejection$24:
 	movq	%rbp, %rbx
 	addq	$48, 8(%rsp)
 	movq	8(%rsp), %r12
+	orq 	%r10, %r12
 L_gen_matrix_buf_rejection$25:
 L_gen_matrix_buf_rejection$22:
 	cmpq	$457, %r12
 	jb  	L_gen_matrix_buf_rejection$23
 	movq	$-1, %rbp
 	cmovb	%rbp, %r10
-	movq	8(%rsp), %r12
+	movq	8(%rsp), %rbp
+	orq 	%r10, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r10
+	movq	$-1, %r12
+	cmovnb	%r12, %r10
 	cmpq	$256, %rbx
 	jb  	L_gen_matrix_buf_rejection$4
 	movq	$-1, %rbp
 	cmovb	%rbp, %r10
-	movq	$504, %r12
+	movq	$504, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$4:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r10
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%rdx,%r12), %ymm4
+	movq	$-1, %r12
+	cmovnb	%r12, %r10
+	movq	%rbp, 8(%rsp)
+	vpermq	$148, (%rdx,%rbp), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -8101,11 +8103,12 @@ L_gen_matrix_buf_rejection$6:
 	vmovdqu	%xmm4, (%r9,%rbp,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %r12
-	addq	$24, %r12
+	movq	8(%rsp), %rbp
+	orq 	%r10, %rbp
+	addq	$24, %rbp
 L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r12
+	cmpq	$481, %rbp
 	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_poly_decompress$1:

--- a/code/jasmin/768/avx2/jkem.s
+++ b/code/jasmin/768/avx2/jkem.s
@@ -7896,14 +7896,23 @@ L_gen_matrix_buf_rejection$1:
 	vmovdqu	glob_data + 0(%rip), %ymm2
 	vmovdqu	glob_data + 64(%rip), %ymm3
 	leaq	glob_data + 2688(%rip), %r11
-	movq	%r8, %rbp
-	jmp 	L_gen_matrix_buf_rejection$20
-L_gen_matrix_buf_rejection$21:
-	movq	$-1, %r12
-	cmove	%r12, %r10
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%rdx,%rbp), %ymm4
-	vpermq	$148, 24(%rdx,%rbp), %ymm5
+	movq	%r8, 8(%rsp)
+	movq	%r8, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$23:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	cmpq	$225, %rbx
+	jb  	L_gen_matrix_buf_rejection$24
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$24:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	vpermq	$148, (%rdx,%r12), %ymm4
+	vpermq	$148, 24(%rdx,%r12), %ymm5
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpshufb	%ymm0, %ymm5, %ymm5
 	vpsrlw	$4, %ymm4, %ymm6
@@ -7952,23 +7961,30 @@ L_gen_matrix_buf_rejection$21:
 	vmovdqu	%xmm5, (%r9,%r13,2)
 	vextracti128	$1, %ymm5, (%r9,%r14,2)
 	movq	%rbp, %rbx
-	movq	8(%rsp), %rbp
-	addq	$48, %rbp
-L_gen_matrix_buf_rejection$20:
-	cmpq	$457, %rbp
-	setb	%r12b
-	cmpq	$225, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$21
-	movq	$-1, %r12
-	cmovne	%r12, %r10
+	addq	$48, 8(%rsp)
+	movq	8(%rsp), %r12
+L_gen_matrix_buf_rejection$25:
+L_gen_matrix_buf_rejection$22:
+	cmpq	$457, %r12
+	jb  	L_gen_matrix_buf_rejection$23
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	8(%rsp), %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r12
-	cmove	%r12, %r10
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%rdx,%rbp), %ymm4
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	cmpq	$256, %rbx
+	jb  	L_gen_matrix_buf_rejection$4
+	movq	$-1, %rbp
+	cmovb	%rbp, %r10
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$2
+L_gen_matrix_buf_rejection$4:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r10
+	movq	%r12, 8(%rsp)
+	vpermq	$148, (%rdx,%r12), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -7994,11 +8010,23 @@ L_gen_matrix_buf_rejection$3:
 	vpshufb	%ymm5, %ymm4, %ymm4
 	vmovdqu	%xmm4, %xmm5
 	cmpq	$248, %rbx
-	jbe 	L_gen_matrix_buf_rejection$12
+	jbe 	L_gen_matrix_buf_rejection$14
 	movq	$-1, %r13
 	cmovbe	%r13, %r10
 	movq	%xmm5, %r13
 	cmpq	$252, %rbx
+	jbe 	L_gen_matrix_buf_rejection$20
+	movq	$-1, %r14
+	cmovbe	%r14, %r10
+	jmp 	L_gen_matrix_buf_rejection$21
+L_gen_matrix_buf_rejection$20:
+	movq	$-1, %r14
+	cmovnbe	%r14, %r10
+	movq	%r13, (%r9,%rbx,2)
+	vpextrq	$1, %xmm5, %r13
+	addq	$4, %rbx
+L_gen_matrix_buf_rejection$21:
+	cmpq	$254, %rbx
 	jbe 	L_gen_matrix_buf_rejection$18
 	movq	$-1, %r14
 	cmovbe	%r14, %r10
@@ -8006,45 +8034,45 @@ L_gen_matrix_buf_rejection$3:
 L_gen_matrix_buf_rejection$18:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r10
-	movq	%r13, (%r9,%rbx,2)
-	vpextrq	$1, %xmm5, %r13
-	addq	$4, %rbx
-L_gen_matrix_buf_rejection$19:
-	cmpq	$254, %rbx
-	jbe 	L_gen_matrix_buf_rejection$16
-	movq	$-1, %r14
-	cmovbe	%r14, %r10
-	jmp 	L_gen_matrix_buf_rejection$17
-L_gen_matrix_buf_rejection$16:
-	movq	$-1, %r14
-	cmovnbe	%r14, %r10
 	movl	%r13d, (%r9,%rbx,2)
 	shrq	$32, %r13
 	addq	$2, %rbx
-L_gen_matrix_buf_rejection$17:
+L_gen_matrix_buf_rejection$19:
 	cmpq	$255, %rbx
-	jbe 	L_gen_matrix_buf_rejection$14
+	jbe 	L_gen_matrix_buf_rejection$16
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$14:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$16:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r10
 	movw	%r13w, (%r9,%rbx,2)
-L_gen_matrix_buf_rejection$15:
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$12:
+L_gen_matrix_buf_rejection$17:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$14:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
 	vmovdqu	%xmm5, (%r9,%rbx,2)
-L_gen_matrix_buf_rejection$13:
+L_gen_matrix_buf_rejection$15:
 	vextracti128	$1, %ymm4, %xmm4
 	cmpq	$248, %rbp
-	jbe 	L_gen_matrix_buf_rejection$4
+	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
 	movq	%xmm4, %rbx
 	cmpq	$252, %rbp
+	jbe 	L_gen_matrix_buf_rejection$12
+	movq	$-1, %r13
+	cmovbe	%r13, %r10
+	jmp 	L_gen_matrix_buf_rejection$13
+L_gen_matrix_buf_rejection$12:
+	movq	$-1, %r13
+	cmovnbe	%r13, %r10
+	movq	%rbx, (%r9,%rbp,2)
+	vpextrq	$1, %xmm4, %rbx
+	addq	$4, %rbp
+L_gen_matrix_buf_rejection$13:
+	cmpq	$254, %rbp
 	jbe 	L_gen_matrix_buf_rejection$10
 	movq	$-1, %r13
 	cmovbe	%r13, %r10
@@ -8052,48 +8080,33 @@ L_gen_matrix_buf_rejection$13:
 L_gen_matrix_buf_rejection$10:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
-	movq	%rbx, (%r9,%rbp,2)
-	vpextrq	$1, %xmm4, %rbx
-	addq	$4, %rbp
-L_gen_matrix_buf_rejection$11:
-	cmpq	$254, %rbp
-	jbe 	L_gen_matrix_buf_rejection$8
-	movq	$-1, %r13
-	cmovbe	%r13, %r10
-	jmp 	L_gen_matrix_buf_rejection$9
-L_gen_matrix_buf_rejection$8:
-	movq	$-1, %r13
-	cmovnbe	%r13, %r10
 	movl	%ebx, (%r9,%rbp,2)
 	shrq	$32, %rbx
 	addq	$2, %rbp
-L_gen_matrix_buf_rejection$9:
+L_gen_matrix_buf_rejection$11:
 	cmpq	$255, %rbp
-	jbe 	L_gen_matrix_buf_rejection$6
+	jbe 	L_gen_matrix_buf_rejection$8
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r10
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$6:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$8:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r10
 	movw	%bx, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$7:
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$4:
+L_gen_matrix_buf_rejection$9:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbx
 	cmovnbe	%rbx, %r10
 	vmovdqu	%xmm4, (%r9,%rbp,2)
-L_gen_matrix_buf_rejection$5:
+L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %rbp
-	addq	$24, %rbp
+	movq	8(%rsp), %r12
+	addq	$24, %r12
+L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %rbp
-	setb	%r12b
-	cmpq	$256, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$3
+	cmpq	$481, %r12
+	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_poly_decompress$1:
 	leaq	glob_data + 992(%rip), %rdi

--- a/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
+++ b/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
@@ -8748,29 +8748,6 @@ module M = {
     }
     return rp;
   }
-  proc comp_u64_l_int_and_u64_l_int (a:W64.t, b:int, c:W64.t, d:int) : bool = {
-    var c3:bool;
-    var _of_:bool;
-    var _cf_:bool;
-    var _sf_:bool;
-    var _zf_:bool;
-    var c1:bool;
-    var bc1:W8.t;
-    var c2:bool;
-    var bc2:W8.t;
-    var  _0:bool;
-    var  _1:bool;
-    var  _2:bool;
-    (_of_, _cf_, _sf_,  _0, _zf_) <- (CMP_64 a (W64.of_int b));
-    c1 <- (_uLT _of_ _cf_ _sf_ _zf_);
-    bc1 <- (SETcc c1);
-    (_of_, _cf_, _sf_,  _1, _zf_) <- (CMP_64 c (W64.of_int d));
-    c2 <- (_uLT _of_ _cf_ _sf_ _zf_);
-    bc2 <- (SETcc c2);
-    (_of_, _cf_, _sf_,  _2, _zf_) <- (TEST_8 bc1 bc2);
-    c3 <- (_NEQ _of_ _cf_ _sf_ _zf_);
-    return c3;
-  }
   proc __gen_matrix_buf_rejection_filter48 (pol:W16.t Array256.t,
                                             counter:W64.t,
                                             buf:W8.t Array536.t,
@@ -9032,6 +9009,7 @@ module M = {
     var bounds:W256.t;
     var ones:W256.t;
     var sst:W8.t Array2048.t;
+    var saved_buf_offset:W64.t;
     var condition_loop:bool;
     sst <- witness;
     ms <- (init_msf);
@@ -9041,32 +9019,45 @@ module M = {
     bounds <- sample_q;
     ones <- sample_ones;
     sst <- sample_shuffle_table;
+    saved_buf_offset <- buf_offset;
     buf_offset <- buf_offset;
-    condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-    (((3 * 168) - 48) + 1), counter, ((256 - 32) + 1));
+    condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 48) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
-      (* Erased call to spill *)
-      (pol, counter) <@ __gen_matrix_buf_rejection_filter48 (pol, counter,
-      buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
-      (* Erased call to unspill *)
-      buf_offset <- (buf_offset + (W64.of_int 48));
-      condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-      (((3 * 168) - 48) + 1), counter, ((256 - 32) + 1));
+      condition_loop <- (counter \ult (W64.of_int ((256 - 32) + 1)));
+      if (condition_loop) {
+        ms <- (update_msf condition_loop ms);
+        (pol, counter) <@ __gen_matrix_buf_rejection_filter48 (pol, counter,
+        buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
+        saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
+        buf_offset <- saved_buf_offset;
+      } else {
+        ms <- (update_msf (! condition_loop) ms);
+        buf_offset <- (W64.of_int (3 * 168));
+      }
+      condition_loop <-
+      (buf_offset \ult (W64.of_int (((3 * 168) - 48) + 1)));
     }
     ms <- (update_msf (! condition_loop) ms);
-    condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-    (((3 * 168) - 24) + 1), counter, 256);
+    buf_offset <- saved_buf_offset;
+    condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
-      (* Erased call to spill *)
-      (pol, counter, ms) <@ __gen_matrix_buf_rejection_filter24 (pol,
-      counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
-      ms);
-      (* Erased call to unspill *)
-      buf_offset <- (buf_offset + (W64.of_int 24));
-      condition_loop <@ comp_u64_l_int_and_u64_l_int (buf_offset,
-      (((3 * 168) - 24) + 1), counter, 256);
+      condition_loop <- (counter \ult (W64.of_int 256));
+      if (condition_loop) {
+        ms <- (update_msf condition_loop ms);
+        (* Erased call to spill *)
+        (pol, counter, ms) <@ __gen_matrix_buf_rejection_filter24 (pol,
+        counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
+        ms);
+        (* Erased call to unspill *)
+        buf_offset <- (buf_offset + (W64.of_int 24));
+      } else {
+        ms <- (update_msf (! condition_loop) ms);
+        buf_offset <- (W64.of_int (3 * 168));
+      }
+      condition_loop <-
+      (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     }
     return (pol, counter);
   }

--- a/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
+++ b/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
@@ -9031,6 +9031,7 @@ module M = {
         buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
         saved_buf_offset <- (saved_buf_offset + (W64.of_int 48));
         buf_offset <- saved_buf_offset;
+        buf_offset <- (protect_64 buf_offset ms);
       } else {
         ms <- (update_msf (! condition_loop) ms);
         buf_offset <- (W64.of_int (3 * 168));
@@ -9040,6 +9041,7 @@ module M = {
     }
     ms <- (update_msf (! condition_loop) ms);
     buf_offset <- saved_buf_offset;
+    buf_offset <- (protect_64 buf_offset ms);
     condition_loop <- (buf_offset \ult (W64.of_int (((3 * 168) - 24) + 1)));
     while (condition_loop) {
       ms <- (update_msf condition_loop ms);
@@ -9051,6 +9053,7 @@ module M = {
         counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, 
         ms);
         (* Erased call to unspill *)
+        buf_offset <- (protect_64 buf_offset ms);
         buf_offset <- (buf_offset + (W64.of_int 24));
       } else {
         ms <- (update_msf (! condition_loop) ms);

--- a/code/jasmin/768/avx2_stack/jkem.s
+++ b/code/jasmin/768/avx2_stack/jkem.s
@@ -9102,28 +9102,30 @@ L_gen_matrix_buf_rejection$24:
 	movq	%rbp, %rbx
 	addq	$48, 8(%rsp)
 	movq	8(%rsp), %r12
+	orq 	%r11, %r12
 L_gen_matrix_buf_rejection$25:
 L_gen_matrix_buf_rejection$22:
 	cmpq	$457, %r12
 	jb  	L_gen_matrix_buf_rejection$23
 	movq	$-1, %rbp
 	cmovb	%rbp, %r11
-	movq	8(%rsp), %r12
+	movq	8(%rsp), %rbp
+	orq 	%r11, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r11
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
 	cmpq	$256, %rbx
 	jb  	L_gen_matrix_buf_rejection$4
 	movq	$-1, %rbp
 	cmovb	%rbp, %r11
-	movq	$504, %r12
+	movq	$504, %rbp
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$4:
-	movq	$-1, %rbp
-	cmovnb	%rbp, %r11
-	movq	%r12, 8(%rsp)
-	vpermq	$148, (%rsi,%r12), %ymm4
+	movq	$-1, %r12
+	cmovnb	%r12, %r11
+	movq	%rbp, 8(%rsp)
+	vpermq	$148, (%rsi,%rbp), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -9240,11 +9242,12 @@ L_gen_matrix_buf_rejection$6:
 	vmovdqu	%xmm4, (%r10,%rbp,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %r12
-	addq	$24, %r12
+	movq	8(%rsp), %rbp
+	orq 	%r11, %rbp
+	addq	$24, %rbp
 L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %r12
+	cmpq	$481, %rbp
 	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_i_poly_decompress$1:

--- a/code/jasmin/768/avx2_stack/jkem.s
+++ b/code/jasmin/768/avx2_stack/jkem.s
@@ -9035,14 +9035,23 @@ L_gen_matrix_buf_rejection$1:
 	vmovdqu	glob_data + 0(%rip), %ymm2
 	vmovdqu	glob_data + 64(%rip), %ymm3
 	leaq	glob_data + 2688(%rip), %r15
-	movq	%r9, %rbp
-	jmp 	L_gen_matrix_buf_rejection$20
-L_gen_matrix_buf_rejection$21:
-	movq	$-1, %r12
-	cmove	%r12, %r11
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%rsi,%rbp), %ymm4
-	vpermq	$148, 24(%rsi,%rbp), %ymm5
+	movq	%r9, 8(%rsp)
+	movq	%r9, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$23:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r11
+	cmpq	$225, %rbx
+	jb  	L_gen_matrix_buf_rejection$24
+	movq	$-1, %rbp
+	cmovb	%rbp, %r11
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$22
+L_gen_matrix_buf_rejection$24:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r11
+	vpermq	$148, (%rsi,%r12), %ymm4
+	vpermq	$148, 24(%rsi,%r12), %ymm5
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpshufb	%ymm0, %ymm5, %ymm5
 	vpsrlw	$4, %ymm4, %ymm6
@@ -9091,23 +9100,30 @@ L_gen_matrix_buf_rejection$21:
 	vmovdqu	%xmm5, (%r10,%r13,2)
 	vextracti128	$1, %ymm5, (%r10,%r14,2)
 	movq	%rbp, %rbx
-	movq	8(%rsp), %rbp
-	addq	$48, %rbp
-L_gen_matrix_buf_rejection$20:
-	cmpq	$457, %rbp
-	setb	%r12b
-	cmpq	$225, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$21
-	movq	$-1, %r12
-	cmovne	%r12, %r11
+	addq	$48, 8(%rsp)
+	movq	8(%rsp), %r12
+L_gen_matrix_buf_rejection$25:
+L_gen_matrix_buf_rejection$22:
+	cmpq	$457, %r12
+	jb  	L_gen_matrix_buf_rejection$23
+	movq	$-1, %rbp
+	cmovb	%rbp, %r11
+	movq	8(%rsp), %r12
 	jmp 	L_gen_matrix_buf_rejection$2
 L_gen_matrix_buf_rejection$3:
-	movq	$-1, %r12
-	cmove	%r12, %r11
-	movq	%rbp, 8(%rsp)
-	vpermq	$148, (%rsi,%rbp), %ymm4
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r11
+	cmpq	$256, %rbx
+	jb  	L_gen_matrix_buf_rejection$4
+	movq	$-1, %rbp
+	cmovb	%rbp, %r11
+	movq	$504, %r12
+	jmp 	L_gen_matrix_buf_rejection$2
+L_gen_matrix_buf_rejection$4:
+	movq	$-1, %rbp
+	cmovnb	%rbp, %r11
+	movq	%r12, 8(%rsp)
+	vpermq	$148, (%rsi,%r12), %ymm4
 	vpshufb	%ymm0, %ymm4, %ymm4
 	vpsrlw	$4, %ymm4, %ymm5
 	vpblendw	$170, %ymm5, %ymm4, %ymm4
@@ -9133,11 +9149,23 @@ L_gen_matrix_buf_rejection$3:
 	vpshufb	%ymm5, %ymm4, %ymm4
 	vmovdqu	%xmm4, %xmm5
 	cmpq	$248, %rbx
-	jbe 	L_gen_matrix_buf_rejection$12
+	jbe 	L_gen_matrix_buf_rejection$14
 	movq	$-1, %r13
 	cmovbe	%r13, %r11
 	movq	%xmm5, %r13
 	cmpq	$252, %rbx
+	jbe 	L_gen_matrix_buf_rejection$20
+	movq	$-1, %r14
+	cmovbe	%r14, %r11
+	jmp 	L_gen_matrix_buf_rejection$21
+L_gen_matrix_buf_rejection$20:
+	movq	$-1, %r14
+	cmovnbe	%r14, %r11
+	movq	%r13, (%r10,%rbx,2)
+	vpextrq	$1, %xmm5, %r13
+	addq	$4, %rbx
+L_gen_matrix_buf_rejection$21:
+	cmpq	$254, %rbx
 	jbe 	L_gen_matrix_buf_rejection$18
 	movq	$-1, %r14
 	cmovbe	%r14, %r11
@@ -9145,45 +9173,45 @@ L_gen_matrix_buf_rejection$3:
 L_gen_matrix_buf_rejection$18:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
-	movq	%r13, (%r10,%rbx,2)
-	vpextrq	$1, %xmm5, %r13
-	addq	$4, %rbx
-L_gen_matrix_buf_rejection$19:
-	cmpq	$254, %rbx
-	jbe 	L_gen_matrix_buf_rejection$16
-	movq	$-1, %r14
-	cmovbe	%r14, %r11
-	jmp 	L_gen_matrix_buf_rejection$17
-L_gen_matrix_buf_rejection$16:
-	movq	$-1, %r14
-	cmovnbe	%r14, %r11
 	movl	%r13d, (%r10,%rbx,2)
 	shrq	$32, %r13
 	addq	$2, %rbx
-L_gen_matrix_buf_rejection$17:
+L_gen_matrix_buf_rejection$19:
 	cmpq	$255, %rbx
-	jbe 	L_gen_matrix_buf_rejection$14
+	jbe 	L_gen_matrix_buf_rejection$16
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r11
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$14:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$16:
 	movq	$-1, %r14
 	cmovnbe	%r14, %r11
 	movw	%r13w, (%r10,%rbx,2)
-L_gen_matrix_buf_rejection$15:
-	jmp 	L_gen_matrix_buf_rejection$13
-L_gen_matrix_buf_rejection$12:
+L_gen_matrix_buf_rejection$17:
+	jmp 	L_gen_matrix_buf_rejection$15
+L_gen_matrix_buf_rejection$14:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r11
 	vmovdqu	%xmm5, (%r10,%rbx,2)
-L_gen_matrix_buf_rejection$13:
+L_gen_matrix_buf_rejection$15:
 	vextracti128	$1, %ymm4, %xmm4
 	cmpq	$248, %rbp
-	jbe 	L_gen_matrix_buf_rejection$4
+	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r11
 	movq	%xmm4, %rbx
 	cmpq	$252, %rbp
+	jbe 	L_gen_matrix_buf_rejection$12
+	movq	$-1, %r13
+	cmovbe	%r13, %r11
+	jmp 	L_gen_matrix_buf_rejection$13
+L_gen_matrix_buf_rejection$12:
+	movq	$-1, %r13
+	cmovnbe	%r13, %r11
+	movq	%rbx, (%r10,%rbp,2)
+	vpextrq	$1, %xmm4, %rbx
+	addq	$4, %rbp
+L_gen_matrix_buf_rejection$13:
+	cmpq	$254, %rbp
 	jbe 	L_gen_matrix_buf_rejection$10
 	movq	$-1, %r13
 	cmovbe	%r13, %r11
@@ -9191,48 +9219,33 @@ L_gen_matrix_buf_rejection$13:
 L_gen_matrix_buf_rejection$10:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r11
-	movq	%rbx, (%r10,%rbp,2)
-	vpextrq	$1, %xmm4, %rbx
-	addq	$4, %rbp
-L_gen_matrix_buf_rejection$11:
-	cmpq	$254, %rbp
-	jbe 	L_gen_matrix_buf_rejection$8
-	movq	$-1, %r13
-	cmovbe	%r13, %r11
-	jmp 	L_gen_matrix_buf_rejection$9
-L_gen_matrix_buf_rejection$8:
-	movq	$-1, %r13
-	cmovnbe	%r13, %r11
 	movl	%ebx, (%r10,%rbp,2)
 	shrq	$32, %rbx
 	addq	$2, %rbp
-L_gen_matrix_buf_rejection$9:
+L_gen_matrix_buf_rejection$11:
 	cmpq	$255, %rbp
-	jbe 	L_gen_matrix_buf_rejection$6
+	jbe 	L_gen_matrix_buf_rejection$8
 	movq	$-1, %rbx
 	cmovbe	%rbx, %r11
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$6:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$8:
 	movq	$-1, %r13
 	cmovnbe	%r13, %r11
 	movw	%bx, (%r10,%rbp,2)
-L_gen_matrix_buf_rejection$7:
-	jmp 	L_gen_matrix_buf_rejection$5
-L_gen_matrix_buf_rejection$4:
+L_gen_matrix_buf_rejection$9:
+	jmp 	L_gen_matrix_buf_rejection$7
+L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbx
 	cmovnbe	%rbx, %r11
 	vmovdqu	%xmm4, (%r10,%rbp,2)
-L_gen_matrix_buf_rejection$5:
+L_gen_matrix_buf_rejection$7:
 	movq	%r12, %rbx
-	movq	8(%rsp), %rbp
-	addq	$24, %rbp
+	movq	8(%rsp), %r12
+	addq	$24, %r12
+L_gen_matrix_buf_rejection$5:
 L_gen_matrix_buf_rejection$2:
-	cmpq	$481, %rbp
-	setb	%r12b
-	cmpq	$256, %rbx
-	setb	%r13b
-	testb	%r13b, %r12b
-	jne 	L_gen_matrix_buf_rejection$3
+	cmpq	$481, %r12
+	jb  	L_gen_matrix_buf_rejection$3
 	ret
 L_i_poly_decompress$1:
 	leaq	glob_data + 992(%rip), %rdi

--- a/code/jasmin/common/avx2/gen_matrix.jinc
+++ b/code/jasmin/common/avx2/gen_matrix.jinc
@@ -1,32 +1,5 @@
 require "mlkem_keccak_avx2.jinc"
 
-// a < b && c < d
-inline fn comp_u64_l_int_and_u64_l_int(
-  reg u64 a,
-  inline int b,
-  reg u64 c,
-  inline int d)
-  ->
-  reg bool
-{
-  reg bool c1 c2 c3;
-  reg u8 bc1 bc2;
-
-  ?{ "<u" = c1 } = #CMP_64(a, b);
-  // if(c1) <=> if(a <u b)
-  bc1 = #SETcc(c1);
-
-  ?{ "<u" = c2 } = #CMP_64(c, d);
-  // if(c2) <=> if(a <u c)
-  bc2 = #SETcc(c2);
-
-  // zf == 1 => bc1 & bc2 == 0 => cond = false
-  // zf == 0 => bc1 & bc2 == 1 => cond = true
-  ?{ "!=" = c3 } = #TEST_8(bc1, bc2);
-
-  return c3;
-}
-
 // BUF_size per entry: 21(rate) + 21(rate) + 25(keccak_state) + 1(pad)
 param int BUF_size = 536; // 168*2+200      (was in u64s: 3*21 + 4 + 1; //544 bytes;
 
@@ -319,6 +292,7 @@ fn _gen_matrix_buf_rejection
   reg ptr u8[2048] sst;
   reg u256 load_shuffle mask bounds ones;
   #msf reg u64 ms;
+  stack u64 saved_buf_offset;
 
   ms = #init_msf();
 
@@ -328,29 +302,45 @@ fn _gen_matrix_buf_rejection
   ones = sample_ones;
   sst = sample_shuffle_table;
 
+  saved_buf_offset = buf_offset;
   buf_offset = buf_offset;
 
   while
-    { condition_loop = comp_u64_l_int_and_u64_l_int(buf_offset, 3*168-48+1, counter, MLKEM_N-32+1);
+    { condition_loop = buf_offset <u 3 * 168 - 48 + 1;
     }
   ( condition_loop )
     {
     ms = #update_msf(condition_loop, ms);
-() = #spill(buf_offset);
-    pol, counter = __gen_matrix_buf_rejection_filter48(pol, counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
-() = #unspill(buf_offset);
-    buf_offset += 48;
+    condition_loop = counter <u MLKEM_N - 32 + 1;
+    if condition_loop {
+      ms = #update_msf(condition_loop, ms);
+      pol, counter = __gen_matrix_buf_rejection_filter48(pol, counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
+      saved_buf_offset += 48;
+      buf_offset = saved_buf_offset;
+    } else {
+      ms = #update_msf(!condition_loop, ms);
+      buf_offset = 3 * 168;
+    }
     }
   ms = #update_msf(!condition_loop, ms);
 
-  while { condition_loop = comp_u64_l_int_and_u64_l_int(buf_offset, 3*168-24+1, counter, MLKEM_N); }
+  buf_offset = saved_buf_offset;
+
+  while { condition_loop = buf_offset <u 3 * 168 - 24 + 1; }
         ( condition_loop )
   {
     ms = #update_msf(condition_loop, ms);
+    condition_loop = counter <u MLKEM_N;
+    if condition_loop {
+      ms = #update_msf(condition_loop, ms);
 () = #spill(buf_offset);
-    pol, counter, ms = __gen_matrix_buf_rejection_filter24(pol, counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
+      pol, counter, ms = __gen_matrix_buf_rejection_filter24(pol, counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
 () = #unspill(buf_offset);
-    buf_offset += 24;
+      buf_offset += 24;
+    } else {
+      ms = #update_msf(!condition_loop, ms);
+      buf_offset = 3 * 168;
+    }
   }
 
   return pol, counter;

--- a/code/jasmin/common/avx2/gen_matrix.jinc
+++ b/code/jasmin/common/avx2/gen_matrix.jinc
@@ -317,6 +317,7 @@ fn _gen_matrix_buf_rejection
       pol, counter = __gen_matrix_buf_rejection_filter48(pol, counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
       saved_buf_offset += 48;
       buf_offset = saved_buf_offset;
+      buf_offset = #protect(buf_offset, ms);
     } else {
       ms = #update_msf(!condition_loop, ms);
       buf_offset = 3 * 168;
@@ -325,6 +326,7 @@ fn _gen_matrix_buf_rejection
   ms = #update_msf(!condition_loop, ms);
 
   buf_offset = saved_buf_offset;
+  buf_offset = #protect(buf_offset, ms);
 
   while { condition_loop = buf_offset <u 3 * 168 - 24 + 1; }
         ( condition_loop )
@@ -336,6 +338,7 @@ fn _gen_matrix_buf_rejection
 () = #spill(buf_offset);
       pol, counter, ms = __gen_matrix_buf_rejection_filter24(pol, counter, buf, buf_offset, load_shuffle, mask, bounds, sst, ones, ms);
 () = #unspill(buf_offset);
+      buf_offset = #protect(buf_offset, ms);
       buf_offset += 24;
     } else {
       ms = #update_msf(!condition_loop, ms);

--- a/proof/correctness1024/avx2/MLKEM_genmatrix_avx2.ec
+++ b/proof/correctness1024/avx2/MLKEM_genmatrix_avx2.ec
@@ -514,7 +514,7 @@ while ( buf=_buf /\ 24 %| to_uint saved_buf_offset /\ 3 %| to_uint _buf_offset /
  + auto => &m /> *; rewrite ultE /#.
  if; last by auto.
  wp; ecall (buf_rejection_filter48_h pol counter buf buf_offset).
- auto => &m />.
+ auto; rewrite /protect_64 => &m />.
  move => Hdvd1 Hdvd2 Ho1 Ho2 Ho3 Hctr1 Hctr2 Hctr3 + Hbo Hctr4 Hbo4.
  have -> : (min 256 (to_uint counter{m})) = to_uint counter{m} by smt().
  move => H.
@@ -539,7 +539,7 @@ while ( buf=_buf /\ 24 %| to_uint saved_buf_offset /\ 3 %| to_uint _buf_offset /
  have : size (plist p (to_uint counter{m} + size R)) <= 256.
   by rewrite size_plist /#.
  by rewrite HH size_cat size_plist 1:/# ultE to_uintD_small /#.
-wp; skip => &m /> Hctr1 Hctr2 Hbo; split.
+auto; rewrite /protect_64 => &m /> Hctr1 Hctr2 Hbo; split.
  split; first smt().
  split; first smt().
  split; first smt().
@@ -603,7 +603,7 @@ while (condition_loop
  - auto.
  - if; last auto => &m /> /#.
     wp; call buf_rejection_filter24_ll; auto => &m /> H _.
-    rewrite ultE to_uintD_small /#.
+    rewrite /protect_64 ultE to_uintD_small /#.
  by hoare; auto.
 auto => &m />.
 rewrite ultE /#.

--- a/proof/correctness768/avx2/MLKEM_genmatrix_avx2.ec
+++ b/proof/correctness768/avx2/MLKEM_genmatrix_avx2.ec
@@ -508,7 +508,7 @@ while ( buf=_buf /\ 24 %| to_uint saved_buf_offset /\ 3 %| to_uint _buf_offset /
  + auto => &m /> *; rewrite ultE /#.
  if; last by auto.
  wp; ecall (buf_rejection_filter48_h pol counter buf buf_offset).
- auto => &m />.
+ auto; rewrite /protect_64 => &m />.
  move => Hdvd1 Hdvd2 Ho1 Ho2 Ho3 Hctr1 Hctr2 Hctr3 + Hbo Hctr4 Hbo4.
  have -> : (min 256 (to_uint counter{m})) = to_uint counter{m} by smt().
  move => H.
@@ -533,7 +533,7 @@ while ( buf=_buf /\ 24 %| to_uint saved_buf_offset /\ 3 %| to_uint _buf_offset /
  have : size (plist p (to_uint counter{m} + size R)) <= 256.
   by rewrite size_plist /#.
  by rewrite HH size_cat size_plist 1:/# ultE to_uintD_small /#.
-wp; skip => &m /> Hctr1 Hctr2 Hbo; split.
+auto; rewrite /protect_64 => &m /> Hctr1 Hctr2 Hbo; split.
  split; first smt().
  split; first smt().
  split; first smt().
@@ -597,7 +597,7 @@ while (condition_loop
  - auto.
  - if; last auto => &m /> /#.
     wp; call buf_rejection_filter24_ll; auto => &m /> H _.
-    rewrite ultE to_uintD_small /#.
+    rewrite /protect_64 ultE to_uintD_small /#.
  by hoare; auto.
 auto => &m />.
 rewrite ultE /#.

--- a/proof/correctness768/avx2/MLKEM_genmatrix_avx2.ec
+++ b/proof/correctness768/avx2/MLKEM_genmatrix_avx2.ec
@@ -387,68 +387,6 @@ from Keccak require import Keccak1600_avx2x4.
 require import MLKEM_keccak_avx2.
 require import Mlkem_filters_bridge.
 
-hoare comp_u64_l_int_and_u64_l_int_h _a _i1 _b _i2:
- Jkem768_avx2.M(Jkem768_avx2.Syscall).comp_u64_l_int_and_u64_l_int
- : arg = (_a,_i1,_b,_i2)
-   /\ _i1 %% W64.modulus = _i1 /\ _i2 %% W64.modulus = _i2
-   ==>
-   res = (to_uint _a < _i1 && to_uint _b < _i2).
-proof.
-proc; auto => />  E1 E2.
-rewrite /_uLT /CMP_64 /_NEQ /_EQ /TEST_8.
-rewrite /rflags_of_bwop /rflags_of_aluop /SETcc /ZF_of /=.
-case: (to_uint _a < _i1) => C1.
- case: (to_uint _b < _i2) => C2.
-  rewrite !to_uintD !to_uintN !of_uintK.
-  by rewrite ifT 1:/# ifT 1:/# /= to_uint_eq /=.
- rewrite -lezNgt in C2.
- rewrite (W64.to_uintB _b).
-  by rewrite /(\ule)  of_uintK E2.
- rewrite !to_uintD !to_uintN !of_uintK.
- by rewrite ifT 1:/# /=.
-rewrite -lezNgt in C1.
-by rewrite (W64.to_uintB _a) 1:uleE 1:of_uintK 1:E1.
-qed.
-
-lemma comp_u64_l_int_and_u64_l_int_ll:
- islossless Jkem768_avx2.M(Jkem768_avx2.Syscall).comp_u64_l_int_and_u64_l_int.
-proof. by islossless. qed.
-
-phoare comp_u64_l_int_and_u64_l_int_ph _a _i1 _b _i2:
- [Jkem768_avx2.M(Jkem768_avx2.Syscall).comp_u64_l_int_and_u64_l_int
-  : arg = (_a,_i1,_b,_i2)
-    /\ _i1 %% W64.modulus = _i1 /\ _i2 %% W64.modulus = _i2
-    ==>
-    res = (to_uint _a < _i1 /\ to_uint _b < _i2)
- ] = 1%r.
-proof.
-conseq comp_u64_l_int_and_u64_l_int_ll (comp_u64_l_int_and_u64_l_int_h _a _i1 _b _i2).
-smt().
-qed.
-
-hoare conditionloop_h _a _i1 _b _i2:
- Jkem768_avx2.M(Jkem768_avx2.Syscall).comp_u64_l_int_and_u64_l_int
-  : arg = (_a,_i1+1,_b,_i2)
-    /\ (_i1+1) %% W64.modulus = _i1+1
-    /\ (_i2) %% W64.modulus = _i2
-    ==>
-    res = (to_uint _a <=_i1 /\ to_uint _b < _i2).
-proof.
-by conseq (comp_u64_l_int_and_u64_l_int_h _a (_i1+1) _b _i2) => /#.
-qed.
-
-phoare conditionloop_ph _a _i1 _b _i2:
- [Jkem768_avx2.M(Jkem768_avx2.Syscall).comp_u64_l_int_and_u64_l_int
-  : arg = (_a,_i1+1,_b,_i2)
-    /\ (_i1+1) %% W64.modulus = _i1+1
-    /\ _i2 %% W64.modulus = _i2
-    ==>
-    res = (to_uint _a <= _i1 /\ to_uint _b < _i2)
- ] = 1%r.
-proof.
-by conseq comp_u64_l_int_and_u64_l_int_ll (conditionloop_h _a _i1 _b _i2).
-qed.
-
 lemma take_rejection16_done n buf buf_o bo:
  0 <= buf_o <= bo <= 504 =>
  3 %| buf_o =>
@@ -521,10 +459,20 @@ while ( buf=_buf /\ 24 %| to_uint buf_offset /\ 3 %| to_uint _buf_offset /\
          = plist _pol (to_uint _ctr)
            ++ take (256-to_uint _ctr) (rejection16 (buf_subl _buf (to_uint _buf_offset) (to_uint buf_offset)))
         ) /\
-        (condition_loop
-          <=> (to_uint counter < 256 
-               /\ to_uint buf_offset <= 504-24))).
- ecall (conditionloop_h buf_offset (3 * 168 - 24) counter 256); simplify.
+        (condition_loop <=> to_uint buf_offset <= 504-24)).
+ wp.
+ seq 2: (#{/~condition_loop}pre /\ to_uint buf_offset <= 504 - 24 /\ (condition_loop <=> to_uint counter < 256)).
+ + by auto => /> &m *; rewrite ultE.
+ if; last first.
+ + auto => /> &m Hdvd1 Hdvd2 Ho1 Ho2 Ho3 Hctr1 Hctr2 Hctr3 H Hcond1 Hcond2; split; first smt().
+   have : size (take (256 - to_uint _ctr) (rejection16 (buf_subl _buf (to_uint _buf_offset) (to_uint buf_offset{m})))) = 256 - to_uint _ctr.
+   * have : size (plist pol{m} (min 256 (to_uint counter{m}))) = 256 by rewrite size_plist; smt().
+     rewrite H size_cat size_plist; smt().
+   rewrite size_takel' => - [] _ Hsz.
+   move: H; rewrite take_rejection16_done 1, 3:/#; first by [].
+   * rewrite size_take; first smt().
+     by rewrite -/(min _ _) lez_minl.
+   exact.
  wp; ecall (buf_rejection_filter24_h pol counter buf buf_offset).
  auto => &m /> Hdvd1 Hdvd2 Ho1 Ho2 Ho3 Hctr1 Hctr2 Hctr3 H Hcond1 Hcond2.
  have Hsz: min 256 (to_uint counter{m}) = to_uint _ctr + min (256-to_uint _ctr) (size (rejection16 (buf_subl buf{m} (to_uint _buf_offset) (to_uint buf_offset{m})))).
@@ -538,26 +486,27 @@ while ( buf=_buf /\ 24 %| to_uint buf_offset /\ 3 %| to_uint _buf_offset /\
   by move=> *; rewrite !modz_small 1:// /= /#.
  split; first smt(size_ge0). 
  rewrite modz_small; first smt(size_ge0 size_take_min).
+ split; last rewrite ultE to_uintD_small /#.
  rewrite Hc'.
  rewrite Hstep H -catA; congr.
  rewrite -(buf_subl_cat _ (to_uint _buf_offset) (to_uint buf_offset{m}) (to_uint buf_offset{m} + 24)) 1:/#.
  rewrite rejection16_cat.
   by rewrite size_buf_subl /#.
  by rewrite take_catr 1:/#; congr; congr; smt().
-ecall (conditionloop_h buf_offset (3 * 168 - 24) counter 256).
 wp.
-while ( buf=_buf /\ 24 %| to_uint buf_offset /\ 3 %| to_uint _buf_offset /\
-        0 <= to_uint _buf_offset <= to_uint buf_offset <= 504 /\
+while ( buf=_buf /\ 24 %| to_uint saved_buf_offset /\ 3 %| to_uint _buf_offset /\
+        0 <= to_uint _buf_offset <= to_uint saved_buf_offset <= 504 /\
         0 <= to_uint _ctr <= to_uint counter <= 256 /\
         auxdata_ok load_shuffle mask bounds ones sst /\
         plist pol (min 256 (to_uint counter))
         = plist _pol (to_uint _ctr)
-           ++ rejection16 (buf_subl _buf (to_uint _buf_offset) (to_uint buf_offset)) /\
-        to_uint _ctr + size (rejection16 (buf_subl _buf (to_uint _buf_offset) (to_uint buf_offset))) <= 256 /\
-        (condition_loop
-          <=> (to_uint counter <= 256-32
-               /\ to_uint buf_offset <= 504-48))).
- ecall (conditionloop_h buf_offset (3 * 168 - 48) counter (256-32+1)); simplify.
+           ++ rejection16 (buf_subl _buf (to_uint _buf_offset) (to_uint saved_buf_offset)) /\
+        to_uint _ctr + size (rejection16 (buf_subl _buf (to_uint _buf_offset) (to_uint saved_buf_offset))) <= 256 /\
+        (condition_loop <=> to_uint buf_offset <= 504-48) /\
+        (to_uint buf_offset <= 504 - 48 => saved_buf_offset = buf_offset)).
+ seq 2: (#{/~condition_loop}pre /\ to_uint buf_offset <= 504 - 48 /\ saved_buf_offset = buf_offset /\ (condition_loop <=> to_uint counter <= 256 - 32)).
+ + auto => &m /> *; rewrite ultE /#.
+ if; last by auto.
  wp; ecall (buf_rejection_filter48_h pol counter buf buf_offset).
  auto => &m />.
  move => Hdvd1 Hdvd2 Ho1 Ho2 Ho3 Hctr1 Hctr2 Hctr3 + Hbo Hctr4 Hbo4.
@@ -583,8 +532,7 @@ while ( buf=_buf /\ 24 %| to_uint buf_offset /\ 3 %| to_uint _buf_offset /\
  move => HH. 
  have : size (plist p (to_uint counter{m} + size R)) <= 256.
   by rewrite size_plist /#.
- by rewrite HH size_cat size_plist /#.
-ecall (conditionloop_h buf_offset (3 * 168 - 48) counter (256-32+1)); simplify.
+ by rewrite HH size_cat size_plist 1:/# ultE to_uintD_small /#.
 wp; skip => &m /> Hctr1 Hctr2 Hbo; split.
  split; first smt().
  split; first smt().
@@ -593,10 +541,10 @@ wp; skip => &m /> Hctr1 Hctr2 Hbo; split.
  split; 1:  by rewrite pack32_sample_load_shuffle.
  have -> : (min 256 (to_uint counter{m})) = to_uint counter{m} by smt().
  split; 1: by rewrite buf_subl0 1:/# /rejection16 rejection0 cats0.
- split; last  by smt().
+ split; last by rewrite ultE /#.
  by rewrite buf_subl0 1:/# /rejection16 rejection0 /#.
-move => buf_o cond ctr pol Hcond Hdvd1 Hdvd2 Hbo1 Hbo2 Hbo3 Hctr3 Hctr4 _ H Hsz Hterm; split.
- by rewrite take_oversize /#. 
+move => buf_o cond ctr pol saved_buf_offset Hcond Hdvd1 Hdvd2 Hbo1 Hbo2 Hbo3 Hctr3 Hctr4 _ H Hsz Hterm; split.
+ by rewrite ultE take_oversize /#.
 move=> buf_o2 cond2 ctr2 pol2 HC2 Hdvd3 Hbo4 Hbo5 Hctr5 HH.
 case: (to_uint ctr2 < 256) => /= C1.
  move=> C2; move: HH; have ->: to_uint buf_o2 = 504 by smt().
@@ -614,6 +562,7 @@ have HHsz: 256 = to_uint counter{m} + min (256 - to_uint counter{m})
  rewrite -(size_plist pol2 256) 1:/#.
  by rewrite HH size_cat size_plist 1:/# size_take_min /#.
 rewrite size_take_min 1:/#.
+move => _.
 split; first smt(size_rejection16_le).
 move => ->; rewrite HH; congr.
 apply take_rejection16_done; first 3 smt().
@@ -624,42 +573,34 @@ lemma gen_matrix_buf_rejection_ll:
  islossless Jkem768_avx2.M(Jkem768_avx2.Syscall)._gen_matrix_buf_rejection.
 proof.
 proc.
-seq 11: (true)=> //.
- wp; while (condition_loop
-            <=> to_uint counter <= 256-32 
-                /\ to_uint buf_offset <= 504-48)
+seq 13: (true)=> //.
+ wp; while ((condition_loop
+            <=> to_uint buf_offset <= 504-48) /\ (condition_loop => saved_buf_offset = buf_offset))
            (504 - to_uint buf_offset).
   move=> z.
   exlim buf_offset => _buf_offset.
-  seq 2: (#{~condition_loop}pre /\ to_uint buf_offset <= 504 - 48) => //.
-    by call buf_rejection_filter48_ll; auto => />.
-   exlim counter => _counter.
-   call (conditionloop_ph (_buf_offset+W64.of_int 48) (3*168-48) _counter (256-32+1)); simplify.
-   auto => /> *.
-   by rewrite to_uintD_small ?of_uintK /= /#.
-  by hoare; inline*; auto => />.
+  seq 2: (#{~condition_loop} pre /\ saved_buf_offset = buf_offset /\ to_uint buf_offset <= 504 - 48) => //.
+  - by auto => &m />.
+  - if; last by auto => &m /> /#.
+    wp; call buf_rejection_filter48_ll; auto => &m /> H _.
+    rewrite ultE to_uintD_small /#.
+  by hoare; auto => />.
+ auto => &m />.
+ rewrite ultE /#.
  exlim buf_offset => _buf_offset.
  exlim counter => _counter.
- call (conditionloop_ph (_buf_offset) (3*168-48) _counter (256-32+1)); simplify.
- by auto => /> /#.
 while (condition_loop
-       <=> to_uint counter < 256 
-           /\ to_uint buf_offset <= 504-24)
+       <=> to_uint buf_offset <= 504-24)
       (504 - to_uint buf_offset).
  move=> z.
- exlim buf_offset => _buf_offset.
  seq 2: (#{~condition_loop}pre /\ to_uint buf_offset <= 504 - 24) => //.
-   by call buf_rejection_filter24_ll; auto => />.
-  exlim counter => _counter.
-  call (conditionloop_ph (_buf_offset+W64.of_int 24) (3*168-24) _counter 256); simplify.
-  auto => /> *.
-  by rewrite to_uintD_small ?of_uintK /= /#.
- by hoare; inline*; auto => />.
-exlim buf_offset => _buf_offset.
-exlim counter => _counter.
-call (conditionloop_ph (_buf_offset) (3*168-24) _counter 256); simplify.
-inline*; auto => />. 
-by auto => /> * /#.
+ - auto.
+ - if; last auto => &m /> /#.
+    wp; call buf_rejection_filter24_ll; auto => &m /> H _.
+    rewrite ultE to_uintD_small /#.
+ by hoare; auto.
+auto => &m />.
+rewrite ultE /#.
 qed.
 
 phoare gen_matrix_buf_rejection_ph _pol _ctr _buf _buf_offset:


### PR DESCRIPTION
This removes the function `comp_u64_l_int_and_u64_l_int` (and associated proofs) and simplifies the loop structure within `gen_matrix_buf_rejection`: both while loops are in fact simple for loops (with `buf_offset` behaving as the loop counter) with early exit.

The second commit adds a couple of `protect`s and `init_msf` that were missing for the procedure to be SCT.