### PR TITLE
Expand slice in polyvec_compress_1

### DIFF
--- a/code/jasmin/1024/avx2/indcpa.jinc
+++ b/code/jasmin/1024/avx2/indcpa.jinc
@@ -211,7 +211,7 @@ fn __indcpa_enc_1(
   bp = __polyvec_reduce(bp);
   v  = __poly_reduce(v);
 
-  ctp[0:MLKEM_POLYVECCOMPRESSEDBYTES] = __polyvec_compress_1(ctp[0:MLKEM_POLYVECCOMPRESSEDBYTES], bp);
+  ctp[0:MLKEM_POLYVECCOMPRESSEDBYTES+2] = __polyvec_compress_1(ctp[0:MLKEM_POLYVECCOMPRESSEDBYTES+2], bp);
   ctp[MLKEM_POLYVECCOMPRESSEDBYTES:MLKEM_POLYCOMPRESSEDBYTES], v = _poly_compress_1(ctp[MLKEM_POLYVECCOMPRESSEDBYTES:MLKEM_POLYCOMPRESSEDBYTES], v);
 
   return ctp;

--- a/code/jasmin/1024/avx2/polyvec.jinc
+++ b/code/jasmin/1024/avx2/polyvec.jinc
@@ -136,7 +136,7 @@ fn __polyvec_compress(reg u64 rp, stack u16[MLKEM_VECN] a)
 __polyvec_compress_1: same as previous function but writes to the stack
 */
 inline
-fn __polyvec_compress_1(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[MLKEM_VECN] a) -> reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES]
+fn __polyvec_compress_1(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES+2] rp, stack u16[MLKEM_VECN] a) -> reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES+2]
 {
   inline int i;
   reg u256 f0 f1 f2 v v8 off shift1 mask shift2 sllvdidx srlvqidx shufbidx;

--- a/code/jasmin/1024/avx2_stack/indcpa.jinc
+++ b/code/jasmin/1024/avx2_stack/indcpa.jinc
@@ -137,7 +137,7 @@ fn __indcpa_enc(
   v  = __poly_reduce(v);
 
   () = #unspill(ct);
-  ct[0:MLKEM_POLYVECCOMPRESSEDBYTES] = __i_polyvec_compress(ct[0:MLKEM_POLYVECCOMPRESSEDBYTES], bp);
+  ct[0:MLKEM_POLYVECCOMPRESSEDBYTES+2] = __i_polyvec_compress(ct[0:MLKEM_POLYVECCOMPRESSEDBYTES+2], bp);
   ct[MLKEM_POLYVECCOMPRESSEDBYTES:MLKEM_POLYCOMPRESSEDBYTES], v = _i_poly_compress(ct[MLKEM_POLYVECCOMPRESSEDBYTES:MLKEM_POLYCOMPRESSEDBYTES], v);
 
   return ct;

--- a/code/jasmin/1024/avx2_stack/polyvec.jinc
+++ b/code/jasmin/1024/avx2_stack/polyvec.jinc
@@ -64,7 +64,7 @@ u8[32] pvc_shufbidx_s = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,-1,-1,-1,-1,-1,
                          5, 6, 7, 8, 9,10,-1,-1,-1,-1, 0, 0, 1, 2, 3, 4};
 
 inline
-fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES] rp, stack u16[MLKEM_VECN] a) -> reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES]
+fn __i_polyvec_compress(reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES+2] rp, stack u16[MLKEM_VECN] a) -> reg ptr u8[MLKEM_POLYVECCOMPRESSEDBYTES+2]
 {
   inline int i;
   reg u256 f0 f1 f2 v v8 off shift1 mask shift2 sllvdidx srlvqidx shufbidx;


### PR DESCRIPTION
@mbbarbosa 
@mbbarbosa-lectures 
Here's the fix that we discussed in Zulip.
I expanded the slice as you suggested to make sure that all written positions are valid.

I run the tests in 1024/avx2/tests and 1024/avx2_stack/tests are they all pass.

Let me know if there's something more to look at