### PR TITLE
AVX2 implementations are SCT

### DIFF
--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -12,10 +12,16 @@ jobs:
       matrix:
         size: [ '768', '1024' ]
         dir: [ 'ref', 'avx2', 'avx2_stack' ]
+        target: [ 'ct', 'sct' ]
+        exclude:
+          - dir: 'ref'
+            target: 'sct'
+          - dir: 'avx2_stack'
+            target: 'sct'
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-shell --arg full false --run "echo Dependencies OK…"
-    - run: nix-shell --arg full false --run "make -C code/jasmin/${{matrix.size}}/${{matrix.dir}}/ ct"
+    - run: nix-shell --arg full false --run "make -C code/jasmin/${{matrix.size}}/${{matrix.dir}}/ ${{matrix.target}}"

--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -8135,6 +8135,7 @@ module M(SC:Syscall_t) = {
     var buf3_s:W8.t Array128.t;
     var buf3:W8.t Array128.t;
     var nonces:W8.t Array4.t;
+    var  _0:W64.t;
     buf0 <- witness;
     buf0_s <- witness;
     buf1 <- witness;
@@ -8158,6 +8159,7 @@ module M(SC:Syscall_t) = {
     nonces.[3] <- nonce;
     (buf0, buf1, buf2, buf3) <@ _shake256x4_A128__A32_A1 (buf0, buf1, 
     buf2, buf3, seed, nonces);
+     _0 <- (init_msf);
     (* Erased call to unspill *)
     r0 <@ __poly_cbd_eta1 (r0, buf0);
     r1 <@ __poly_cbd_eta1 (r1, buf1);

--- a/code/jasmin/1024/avx2/jkem.jazz
+++ b/code/jasmin/1024/avx2/jkem.jazz
@@ -1,5 +1,6 @@
 require "kem.jinc"
 
+#[sct="transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_keypair_derand(#public reg u64 public_key secret_key coins) -> #public reg u64
 {
   reg u64 r;
@@ -24,6 +25,7 @@ export fn jade_kem_mlkem_mlkem1024_amd64_avx2_keypair_derand(#public reg u64 pub
   return r;
 }
 
+#[sct="transient × transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand(#public reg u64 ciphertext shared_secret public_key coins) -> #public reg u64
 {
   reg u64 r;
@@ -49,6 +51,7 @@ export fn jade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand(#public reg u64 ciphert
   return r;
 }
 
+#[sct="transient × transient → public"]
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_keypair(#public reg u64 public_key secret_key) -> #public reg u64
 {
   reg u64 r;
@@ -67,6 +70,7 @@ export fn jade_kem_mlkem_mlkem1024_amd64_avx2_keypair(#public reg u64 public_key
   return r;
 }
 
+#[sct="transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_enc(#public reg u64 ciphertext shared_secret public_key) -> #public reg u64
 {
   reg u64 r;
@@ -86,6 +90,7 @@ export fn jade_kem_mlkem_mlkem1024_amd64_avx2_enc(#public reg u64 ciphertext sha
   return r;
 }
 
+#[sct="transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem1024_amd64_avx2_dec(#public reg u64 shared_secret ciphertext secret_key) -> #public reg u64
 {
   reg u64 r;

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -13344,6 +13344,8 @@ L_poly_getnoise_eta1_4x$1:
 	call	L_shake256x4_A128__A32_A1$1
 L_poly_getnoise_eta1_4x$2:
 	leaq	824(%rsp), %rsp
+	lfence
+	movq	$0, %rdx
 	movq	544(%rsp), %rdx
 	movq	552(%rsp), %r9
 	movq	560(%rsp), %r10

--- a/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
+++ b/code/jasmin/1024/avx2_stack/extraction/jkem1024_avx2_stack.ec
@@ -7204,6 +7204,7 @@ module M = {
     var buf3_s:W8.t Array128.t;
     var buf3:W8.t Array128.t;
     var nonces:W8.t Array4.t;
+    var  _0:W64.t;
     buf0 <- witness;
     buf0_s <- witness;
     buf1 <- witness;
@@ -7227,6 +7228,7 @@ module M = {
     nonces.[3] <- nonce;
     (buf0, buf1, buf2, buf3) <@ _shake256x4_A128__A32_A1 (buf0, buf1, 
     buf2, buf3, seed, nonces);
+     _0 <- (init_msf);
     (* Erased call to unspill *)
     r0 <@ __poly_cbd_eta1 (r0, buf0);
     r1 <@ __poly_cbd_eta1 (r1, buf1);

--- a/code/jasmin/1024/avx2_stack/jkem.s
+++ b/code/jasmin/1024/avx2_stack/jkem.s
@@ -15285,6 +15285,8 @@ L_poly_getnoise_eta1_4x$1:
 	call	L_shake256x4_A128__A32_A1$1
 L_poly_getnoise_eta1_4x$2:
 	leaq	824(%rsp), %rsp
+	lfence
+	movq	$0, %rdx
 	movq	544(%rsp), %rdx
 	movq	552(%rsp), %r9
 	movq	560(%rsp), %r10

--- a/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
+++ b/code/jasmin/768/avx2/extraction/jkem768_avx2.ec
@@ -7776,6 +7776,7 @@ module M(SC:Syscall_t) = {
     var buf3_s:W8.t Array128.t;
     var buf3:W8.t Array128.t;
     var nonces:W8.t Array4.t;
+    var  _0:W64.t;
     buf0 <- witness;
     buf0_s <- witness;
     buf1 <- witness;
@@ -7799,6 +7800,7 @@ module M(SC:Syscall_t) = {
     nonces.[3] <- nonce;
     (buf0, buf1, buf2, buf3) <@ _shake256x4_A128__A32_A1 (buf0, buf1, 
     buf2, buf3, seed, nonces);
+     _0 <- (init_msf);
     (* Erased call to unspill *)
     r0 <@ __poly_cbd_eta1 (r0, buf0);
     r1 <@ __poly_cbd_eta1 (r1, buf1);

--- a/code/jasmin/768/avx2/jkem.jazz
+++ b/code/jasmin/768/avx2/jkem.jazz
@@ -1,5 +1,6 @@
 require "kem.jinc"
 
+#[sct="transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_keypair_derand(#public reg u64 public_key secret_key coins) -> #public reg u64
 {
   reg u64 r;
@@ -24,6 +25,7 @@ export fn jade_kem_mlkem_mlkem768_amd64_avx2_keypair_derand(#public reg u64 publ
   return r;
 }
 
+#[sct="transient × transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_enc_derand(#public reg u64 ciphertext shared_secret public_key coins) -> #public reg u64
 {
   reg u64 r;
@@ -49,6 +51,7 @@ export fn jade_kem_mlkem_mlkem768_amd64_avx2_enc_derand(#public reg u64 cipherte
   return r;
 }
 
+#[sct="transient × transient → public"]
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_keypair(#public reg u64 public_key secret_key) -> #public reg u64
 {
   reg u64 r;
@@ -67,6 +70,7 @@ export fn jade_kem_mlkem_mlkem768_amd64_avx2_keypair(#public reg u64 public_key 
   return r;
 }
 
+#[sct="transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_enc(#public reg u64 ciphertext shared_secret public_key) -> #public reg u64
 {
   reg u64 r;
@@ -86,6 +90,7 @@ export fn jade_kem_mlkem_mlkem768_amd64_avx2_enc(#public reg u64 ciphertext shar
   return r;
 }
 
+#[sct="transient × transient × transient → public"]
 export fn jade_kem_mlkem_mlkem768_amd64_avx2_dec(#public reg u64 shared_secret ciphertext secret_key) -> #public reg u64
 {
   reg u64 r;

--- a/code/jasmin/768/avx2/jkem.s
+++ b/code/jasmin/768/avx2/jkem.s
@@ -10067,6 +10067,8 @@ L_poly_getnoise_eta1_4x$1:
 	call	L_shake256x4_A128__A32_A1$1
 L_poly_getnoise_eta1_4x$2:
 	leaq	824(%rsp), %rsp
+	lfence
+	movq	$0, %rdx
 	movq	544(%rsp), %rdx
 	movq	552(%rsp), %r8
 	movq	560(%rsp), %r9

--- a/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
+++ b/code/jasmin/768/avx2_stack/extraction/jkem768_avx2_stack.ec
@@ -6882,6 +6882,7 @@ module M = {
     var buf3_s:W8.t Array128.t;
     var buf3:W8.t Array128.t;
     var nonces:W8.t Array4.t;
+    var  _0:W64.t;
     buf0 <- witness;
     buf0_s <- witness;
     buf1 <- witness;
@@ -6905,6 +6906,7 @@ module M = {
     nonces.[3] <- nonce;
     (buf0, buf1, buf2, buf3) <@ _shake256x4_A128__A32_A1 (buf0, buf1, 
     buf2, buf3, seed, nonces);
+     _0 <- (init_msf);
     (* Erased call to unspill *)
     r0 <@ __poly_cbd_eta1 (r0, buf0);
     r1 <@ __poly_cbd_eta1 (r1, buf1);

--- a/code/jasmin/768/avx2_stack/jkem.s
+++ b/code/jasmin/768/avx2_stack/jkem.s
@@ -11549,6 +11549,8 @@ L_poly_getnoise_eta1_4x$1:
 	call	L_shake256x4_A128__A32_A1$1
 L_poly_getnoise_eta1_4x$2:
 	leaq	824(%rsp), %rsp
+	lfence
+	movq	$0, %rsi
 	movq	544(%rsp), %rsi
 	movq	552(%rsp), %r9
 	movq	560(%rsp), %r10

--- a/code/jasmin/common/avx2/poly.jinc
+++ b/code/jasmin/common/avx2/poly.jinc
@@ -581,7 +581,6 @@ fn _poly_getnoise_eta2(#spill_to_mmx reg ptr u16[MLKEM_N] rp, reg ptr u8[MLKEM_S
 /* _poly_getnoise_eta1_4x: computes 4x the binomial noise,
    where only the shake computation is parallelized. */
 
-#[returnaddress="stack"]
 fn _poly_getnoise_eta1_4x
 ( reg ptr u16[MLKEM_N] r0 r1 r2 r3
 , reg ptr u8[MLKEM_SYMBYTES] seed
@@ -609,6 +608,8 @@ fn _poly_getnoise_eta1_4x
 
 
   buf0, buf1, buf2, buf3 = _shake256x4_A128__A32_A1(buf0, buf1, buf2, buf3, seed, nonces);
+
+  _ = #init_msf();
 
 () = #unspill(r0,r1,r2,r3);
   r0 = __poly_cbd_eta1(r0, buf0);

--- a/shell.nix
+++ b/shell.nix
@@ -10,11 +10,9 @@ with pkgs;
 
 let jasmin =
   jasmin-compiler.overrideAttrs (o: {
-    src = fetchFromGitLab {
-      owner = "jasmin-lang";
-      repo = "jasmin-compiler";
-      rev = "v2025.06.0";
-      hash = "sha256-pATAWGsp6bFWg5m1O5Sg86hDOS8TN++DN+dXgXdSn5w=";
+    src = fetchurl {
+      url = "https://gitlab.com/jasmin-lang/jasmin/-/jobs/10462711227/artifacts/raw/compiler/jasmin-compiler-e78ebb66.tgz";
+      hash = "sha256-i60qPD9WvrIKq4DVArwmHmF8Jml86OYyb6aIuLTFgok=";
     };
   })
 ; in


### PR DESCRIPTION
This adds SCT contracts to AVX2 implementations and adds a missing fence in `poly_getnoise_eta1_4x` to safely unspill from the stack.