### PR TITLE
[ci]: disable heat-map

### DIFF
--- a/.github/workflows/ec.yml
+++ b/.github/workflows/ec.yml
@@ -60,6 +60,7 @@ jobs:
               "${{ matrix.dir }}"
     heatmap_proofs:
         name: Generate Heat-Map Proofs
+        if: false
         runs-on: ubuntu-latest
         strategy:
           fail-fast: false


### PR DESCRIPTION
This is WIP and it slow downs the CI by run the proofs a second time.