### PR TITLE
MLKEM-1024/AVX2: use 256-bit memory accesses instead of 64-bit ones

### DIFF
--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -9740,6 +9740,7 @@ module M = {
   proc __crypto_kem_dec_jazz (shk:W8.t Array32.t, ct:W8.t Array1568.t,
                               sk:W8.t Array3168.t) : W8.t Array32.t = {
     var aux:W8.t Array32.t;
+    var z:W256.t;
     var zp_ct:W8.t Array1600.t;
     var buf:W8.t Array64.t;
     var k:W256.t;
@@ -9751,36 +9752,13 @@ module M = {
     kr <- witness;
     zp_ct <- witness;
     (* Erased call to spill *)
+    z <-
+    (get256_direct (WArray3168.init8 (fun i => sk.[i]))
+    ((((4 * 384) + ((4 * 384) + 32)) + (2 * 32)) - 32));
     zp_ct <-
     (Array1600.init
-    (fun i => (if (0 <= i < (0 + 32)) then (Array32.init
-                                           (fun i => (get8
-                                                     (WArray32.init64
-                                                     (fun i => (copy_64
-                                                               (Array4.init
-                                                               (fun i => 
-                                                               (get64
-                                                               (
-                                                               WArray32.init8
-                                                               (fun i => 
-                                                               (Array32.init
-                                                               (fun i => 
-                                                               sk.[((
-                                                                    (
-                                                                    (
-                                                                    (4 * 384) +
-                                                                    (
-                                                                    (4 * 384) +
-                                                                    32)) +
-                                                                    (2 * 32)) -
-                                                                    32) +
-                                                                   i)])
-                                                               ).[i])) 
-                                                               i)))).[
-                                                               i])
-                                                     ) i))
-                                           ).[(i - 0)] else zp_ct.[i]))
-    );
+    (WArray1600.get8
+    (WArray1600.set256 (WArray1600.init8 (fun i => zp_ct.[i])) 0 z)));
     aux <@ __indcpa_dec ((Array32.init (fun i => buf.[(0 + i)])), ct,
     (Array1536.init (fun i => sk.[(0 + i)])));
     buf <-

--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -9742,6 +9742,7 @@ module M = {
     var aux:W8.t Array32.t;
     var zp_ct:W8.t Array1600.t;
     var buf:W8.t Array64.t;
+    var k:W256.t;
     var kr:W8.t Array64.t;
     var ctc:W8.t Array1568.t;
     var cnd:W64.t;
@@ -9785,31 +9786,12 @@ module M = {
     buf <-
     (Array64.init
     (fun i => (if (0 <= i < (0 + 32)) then aux.[(i - 0)] else buf.[i])));
+    k <-
+    (get256_direct (WArray3168.init8 (fun i => sk.[i]))
+    ((4 * 384) + ((4 * 384) + 32)));
     buf <-
     (Array64.init
-    (fun i => (if (32 <= i < (32 + 32)) then (Array32.init
-                                             (fun i => (get8
-                                                       (WArray32.init64
-                                                       (fun i => (copy_64
-                                                                 (Array4.init
-                                                                 (fun i => 
-                                                                 (get64
-                                                                 (
-                                                                 WArray32.init8
-                                                                 (fun i => 
-                                                                 (
-                                                                 Array32.init
-                                                                 (fun i => 
-                                                                 sk.[
-                                                                 (((4 * 384) +
-                                                                  ((4 * 384) +
-                                                                  32)) +
-                                                                 i)])).[
-                                                                 i])) 
-                                                                 i)))).[
-                                                                 i])
-                                                       ) i))
-                                             ).[(i - 32)] else buf.[i]))
+    (WArray64.get8 (WArray64.set256 (WArray64.init8 (fun i => buf.[i])) 1 k))
     );
     kr <@ _sha3_512A_A64 (kr, buf);
     ctc <@ __indcpa_enc (ctc, (Array32.init (fun i => buf.[(0 + i)])),

--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -9690,6 +9690,7 @@ module M = {
     var aux:W8.t Array32.t;
     var buf:W8.t Array64.t;
     var kr:W8.t Array64.t;
+    var k:W256.t;
     buf <- witness;
     kr <- witness;
     (* Erased call to spill *)
@@ -9720,20 +9721,10 @@ module M = {
     ct <@ __indcpa_enc (ct, (Array32.init (fun i => buf.[(0 + i)])), 
     pk, (Array32.init (fun i => kr.[(32 + i)])));
     (* Erased call to unspill *)
+    k <- (get256 (WArray64.init8 (fun i => kr.[i])) 0);
     shk <-
     (Array32.init
-    (fun i => (get8
-              (WArray32.init64
-              (fun i => (copy_64
-                        (Array4.init
-                        (fun i => (get64
-                                  (WArray32.init8
-                                  (fun i => (Array32.init
-                                            (fun i => kr.[(0 + i)])).[
-                                            i])
-                                  ) i))
-                        )).[i])
-              ) i))
+    (WArray32.get8 (WArray32.set256 (WArray32.init8 (fun i => shk.[i])) 0 k))
     );
     return (ct, shk);
   }

--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -9688,29 +9688,17 @@ module M = {
                               pk:W8.t Array1568.t, randomnessp:W8.t Array32.t) : 
   W8.t Array1568.t * W8.t Array32.t = {
     var aux:W8.t Array32.t;
+    var b:W256.t;
     var buf:W8.t Array64.t;
     var kr:W8.t Array64.t;
     var k:W256.t;
     buf <- witness;
     kr <- witness;
     (* Erased call to spill *)
+    b <- (get256 (WArray32.init8 (fun i => randomnessp.[i])) 0);
     buf <-
     (Array64.init
-    (fun i => (if (0 <= i < (0 + 32)) then (Array32.init
-                                           (fun i => (get8
-                                                     (WArray32.init64
-                                                     (fun i => (copy_64
-                                                               (Array4.init
-                                                               (fun i => 
-                                                               (get64
-                                                               (
-                                                               WArray32.init8
-                                                               (fun i => 
-                                                               randomnessp.[
-                                                               i])) i)))).[
-                                                               i])
-                                                     ) i))
-                                           ).[(i - 0)] else buf.[i]))
+    (WArray64.get8 (WArray64.set256 (WArray64.init8 (fun i => buf.[i])) 0 b))
     );
     aux <@ _sha3_256A_A1568 ((Array32.init (fun i => buf.[(32 + i)])), pk);
     buf <-

--- a/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
+++ b/code/jasmin/1024/avx2/extraction/jkem1024_avx2.ec
@@ -6,12 +6,12 @@ import SLH64.
 
 require import
 Array1 Array2 Array4 Array5 Array6 Array7 Array8 Array16 Array24 Array25
-Array32 Array33 Array64 Array128 Array160 Array196 Array256 Array384 Array400
-Array536 Array1024 Array1410 Array1536 Array1568 Array1600 Array2048
-Array2144 Array3168 Array4096 WArray1 WArray2 WArray4 WArray8 WArray16
-WArray32 WArray33 WArray64 WArray128 WArray160 WArray192 WArray200 WArray224
-WArray256 WArray384 WArray512 WArray536 WArray800 WArray1410 WArray1536
-WArray1568 WArray1600 WArray2048 WArray2144 WArray3168 WArray8192.
+Array32 Array33 Array64 Array128 Array160 Array256 Array384 Array400 Array536
+Array1024 Array1410 Array1536 Array1568 Array1600 Array2048 Array2144
+Array3168 Array4096 WArray1 WArray2 WArray4 WArray8 WArray16 WArray32
+WArray33 WArray64 WArray128 WArray160 WArray192 WArray200 WArray224 WArray256
+WArray384 WArray512 WArray536 WArray800 WArray1410 WArray1536 WArray1568
+WArray1600 WArray2048 WArray2144 WArray3168 WArray8192.
 
 abbrev gen_matrix_indexes =
 ((Array64.of_list witness)
@@ -9719,6 +9719,7 @@ module M = {
   proc __crypto_kem_dec_jazz (shk:W8.t Array32.t, ct:W8.t Array1568.t,
                               sk:W8.t Array3168.t) : W8.t Array32.t = {
     var aux:W8.t Array32.t;
+    var inc:int;
     var z:W256.t;
     var zp_ct:W8.t Array1600.t;
     var buf:W8.t Array64.t;
@@ -9726,6 +9727,8 @@ module M = {
     var kr:W8.t Array64.t;
     var ctc:W8.t Array1568.t;
     var cnd:W64.t;
+    var j:int;
+    var c:W256.t;
     buf <- witness;
     ctc <- witness;
     kr <- witness;
@@ -9756,26 +9759,17 @@ module M = {
     (Array32.init (fun i => kr.[(32 + i)])));
     (* Erased call to unspill *)
     cnd <@ __verify (ct, ctc);
-    zp_ct <-
-    (Array1600.init
-    (fun i => (if (32 <= i < (32 + 1568)) then (Array1568.init
-                                               (fun i => (get8
-                                                         (WArray1568.init64
-                                                         (fun i => (copy_64
-                                                                   (
-                                                                   Array196.init
-                                                                   (fun i => 
-                                                                   (get64
-                                                                   (
-                                                                   WArray1568.init8
-                                                                   (fun i => 
-                                                                   ct.[
-                                                                   i])) 
-                                                                   i)))).[
-                                                                   i])
-                                                         ) i))
-                                               ).[(i - 32)] else zp_ct.[i]))
-    );
+    inc <- (((4 * 352) + 160) %/ 32);
+    j <- 0;
+    while ((j < inc)) {
+      c <- (get256 (WArray1568.init8 (fun i => ct.[i])) j);
+      zp_ct <-
+      (Array1600.init
+      (WArray1600.get8
+      (WArray1600.set256 (WArray1600.init8 (fun i => zp_ct.[i]))
+      ((32 %/ 32) + j) c)));
+      j <- (j + 1);
+    }
     (* Erased call to unspill *)
     shk <@ _shake256_A32__A1600 (shk, zp_ct);
     shk <@ __cmov (shk, (Array32.init (fun i => kr.[(0 + i)])), cnd);

--- a/code/jasmin/1024/avx2/indcpa.jinc
+++ b/code/jasmin/1024/avx2/indcpa.jinc
@@ -25,7 +25,7 @@ fn __indcpa_keypair(#[spill_to_mmx] reg ptr u8[MLKEM_PUBLICKEYBYTES] pk, #[spill
 
   for i = 0 to MLKEM_SYMBYTES/8
   {
-    t64 = randomnessp[:u64 i];
+    t64 = randomnessp[#unaligned:u64 i];
     inbuf[:u64 i] = t64;
   }
   inbuf[32] = MLKEM_K;

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -6364,14 +6364,8 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$1:
 	vmovdqu	%xmm2, 140(%rax)
 	movd	%xmm3, 156(%rax)
 	movq	%mm1, %rsi
-	movq	64(%rsp), %rcx
-	movq	%rcx, (%rsi)
-	movq	72(%rsp), %rcx
-	movq	%rcx, 8(%rsi)
-	movq	80(%rsp), %rcx
-	movq	%rcx, 16(%rsi)
-	movq	88(%rsp), %rcx
-	movq	%rcx, 24(%rsi)
+	vmovdqu	64(%rsp), %ymm0
+	vmovdqu	%ymm0, (%rsi)
 	xorl	%eax, %eax
 	movq	18592(%rsp), %rbx
 	movq	18600(%rsp), %rbp
@@ -9955,14 +9949,8 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand$1:
 	vmovdqu	%xmm2, 140(%rax)
 	movd	%xmm3, 156(%rax)
 	movq	%mm1, %rsi
-	movq	64(%rsp), %rax
-	movq	%rax, (%rsi)
-	movq	72(%rsp), %rax
-	movq	%rax, 8(%rsi)
-	movq	80(%rsp), %rax
-	movq	%rax, 16(%rsi)
-	movq	88(%rsp), %rax
-	movq	%rax, 24(%rsi)
+	vmovdqu	64(%rsp), %ymm0
+	vmovdqu	%ymm0, (%rsi)
 	xorl	%eax, %eax
 	movq	18592(%rsp), %rbx
 	movq	18600(%rsp), %rbp

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -22,15 +22,8 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_dec:
 	movq	$0, %rax
 	movq	%rdi, %mm1
 	movq	%rsi, %mm2
-	leaq	3136(%rdx), %rax
-	movq	(%rax), %rcx
-	movq	%rcx, 3744(%rsp)
-	movq	8(%rax), %rcx
-	movq	%rcx, 3752(%rsp)
-	movq	16(%rax), %rcx
-	movq	%rcx, 3760(%rsp)
-	movq	24(%rax), %rcx
-	movq	%rcx, 3768(%rsp)
+	vmovdqu	3136(%rdx), %ymm0
+	vmovdqu	%ymm0, 3744(%rsp)
 	movq	%rsp, %rax
 	movq	%rdx, %r8
 	leaq	5344(%rsp), %r12
@@ -11782,12 +11775,12 @@ L_i_poly_tobytes$2:
 	vpunpckhqdq	%ymm6, %ymm2, %ymm0
 	vpunpcklqdq	%ymm5, %ymm7, %ymm6
 	vpunpckhqdq	%ymm5, %ymm7, %ymm2
-	vpunpcklqdq	%ymm1, %ymm3, %ymm5
+	vpunpcklqdq	%ymm1, %ymm3, %ymm8
 	vpunpckhqdq	%ymm1, %ymm3, %ymm1
 	vperm2i128	$32, %ymm6, %ymm4, %ymm11
 	vperm2i128	$49, %ymm6, %ymm4, %ymm6
-	vperm2i128	$32, %ymm0, %ymm5, %ymm4
-	vperm2i128	$49, %ymm0, %ymm5, %ymm0
+	vperm2i128	$32, %ymm0, %ymm8, %ymm4
+	vperm2i128	$49, %ymm0, %ymm8, %ymm0
 	vperm2i128	$32, %ymm1, %ymm2, %ymm3
 	vperm2i128	$49, %ymm1, %ymm2, %ymm1
 	vmovdqu	%ymm11, (%rsi)
@@ -11854,14 +11847,14 @@ L_i_poly_tobytes$2:
 	vperm2i128	$49, %ymm6, %ymm4, %ymm6
 	vperm2i128	$32, %ymm2, %ymm7, %ymm4
 	vperm2i128	$49, %ymm2, %ymm7, %ymm0
-	vperm2i128	$32, %ymm1, %ymm5, %ymm2
-	vperm2i128	$49, %ymm1, %ymm5, %ymm7
+	vperm2i128	$32, %ymm1, %ymm5, %ymm3
+	vperm2i128	$49, %ymm1, %ymm5, %ymm9
 	vmovdqu	%ymm11, 192(%rsi)
 	vmovdqu	%ymm4, 224(%rsi)
-	vmovdqu	%ymm2, 256(%rsi)
+	vmovdqu	%ymm3, 256(%rsi)
 	vmovdqu	%ymm6, 288(%rsi)
 	vmovdqu	%ymm0, 320(%rsi)
-	vmovdqu	%ymm7, 352(%rsi)
+	vmovdqu	%ymm9, 352(%rsi)
 	ret
 L_poly_sub$1:
 	vmovdqu	(%rsi), %ymm2
@@ -14166,18 +14159,18 @@ L_i_poly_frombytes$1:
 	vperm2i128	$32, %ymm1, %ymm2, %ymm8
 	vperm2i128	$49, %ymm1, %ymm2, %ymm6
 	vperm2i128	$32, %ymm5, %ymm3, %ymm1
-	vperm2i128	$49, %ymm5, %ymm3, %ymm2
+	vperm2i128	$49, %ymm5, %ymm3, %ymm9
 	vperm2i128	$32, %ymm7, %ymm4, %ymm5
 	vperm2i128	$49, %ymm7, %ymm4, %ymm7
-	vpunpcklqdq	%ymm2, %ymm8, %ymm9
-	vpunpckhqdq	%ymm2, %ymm8, %ymm2
+	vpunpcklqdq	%ymm9, %ymm8, %ymm10
+	vpunpckhqdq	%ymm9, %ymm8, %ymm2
 	vpunpcklqdq	%ymm5, %ymm6, %ymm3
 	vpunpckhqdq	%ymm5, %ymm6, %ymm5
 	vpunpcklqdq	%ymm7, %ymm1, %ymm6
 	vpunpckhqdq	%ymm7, %ymm1, %ymm1
 	vmovsldup	%ymm5, %ymm11
-	vpblendd	$170, %ymm11, %ymm9, %ymm4
-	vpsrlq	$32, %ymm9, %ymm7
+	vpblendd	$170, %ymm11, %ymm10, %ymm4
+	vpsrlq	$32, %ymm10, %ymm7
 	vpblendd	$170, %ymm5, %ymm7, %ymm5
 	vmovsldup	%ymm6, %ymm11
 	vpblendd	$170, %ymm11, %ymm2, %ymm7
@@ -14810,8 +14803,8 @@ L_shake256_A32__A1600$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14852,8 +14845,8 @@ L_shake256_A32__A1600$9:
 L_shake256_A32__A1600$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14895,8 +14888,8 @@ L_shake256_A32__A1600$6:
 	jb  	L_shake256_A32__A1600$7
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14931,9 +14924,9 @@ L_shake256_A32__A1600$6:
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
-	movq	$1, %rcx
-	shlq	$63, %rcx
-	vmovq	%rcx, %xmm7
+	movq	$1, %rdx
+	shlq	$63, %rdx
+	vmovq	%rdx, %xmm7
 	vpxor	%ymm8, %ymm8, %ymm8
 	vinserti128	$0, %xmm7, %ymm8, %ymm8
 	vpxor	%ymm8, %ymm0, %ymm0
@@ -14989,8 +14982,8 @@ L_sha3_256A_A1568$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -15015,11 +15008,11 @@ L_sha3_256A_A1568$1:
 	vpblendd	$240, %ymm10, %ymm11, %ymm11
 	vpblendd	$195, %ymm12, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm10
+	vpblendd	$240, %ymm10, %ymm13, %ymm12
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm10, %ymm6, %ymm6
+	vpxor	%ymm12, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15031,8 +15024,8 @@ L_sha3_256A_A1568$9:
 L_sha3_256A_A1568$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -15074,8 +15067,8 @@ L_sha3_256A_A1568$6:
 	jb  	L_sha3_256A_A1568$7
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15142,8 +15135,8 @@ L_sha3_256A_A1568$5:
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdi
 	movq	%rdi, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm9
-	movq	%xmm9, 128(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm7
+	movq	%xmm7, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_sha3_256A_A1568$3:
@@ -15504,21 +15497,21 @@ L_shake256_A128__A32_A1$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rdi,%rcx), %xmm9
 	movq	24(%rdi,%rcx), %rdx
-	vmovq	%rdx, %xmm10
+	vmovq	%rdx, %xmm7
 	movq	$0, %rdx
-	vpinsrq	$1, %rdx, %xmm10, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm7, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	$0, %rcx
-	vpxor	%ymm9, %ymm9, %ymm9
-	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%ymm7, %ymm7, %ymm7
+	vpxor	%xmm9, %xmm9, %xmm9
 	movq	$0, %rdx
 	movzbq	(%rax,%rcx), %rax
 	orq 	$7936, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm10, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm9, %xmm10
+	vinserti128	$1, %xmm10, %ymm7, %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15531,8 +15524,8 @@ L_shake256_A128__A32_A1$1:
 L_shake256_A128__A32_A1$4:
 	call	L_keccakf1600_avx2$1
 L_shake256_A128__A32_A1$5:
-	vmovdqu	%xmm4, %xmm9
-	movq	%xmm9, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm7
+	movq	%xmm7, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vmovdqu	%xmm5, %xmm9
 	vextracti128	$1, %ymm5, %xmm7
@@ -15551,8 +15544,8 @@ L_shake256_A128__A32_A1$5:
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdx
 	movq	%rdx, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm9
-	movq	%xmm9, 128(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm7
+	movq	%xmm7, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_shake256_A128__A32_A1$3:
@@ -15590,8 +15583,8 @@ L_sha3_512A_A64$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15638,19 +15631,19 @@ L_sha3_512A_A64$1:
 L_sha3_512A_A64$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A64$5:
-	vmovdqu	%xmm4, %xmm9
-	movq	%xmm9, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm7
+	movq	%xmm7, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
 	movq	%xmm7, %rdi
 	movq	%rdi, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm9
-	vmovdqu	%xmm9, %xmm7
-	vmovdqu	%xmm7, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm9, %xmm9
-	movq	%xmm9, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm7
+	vmovdqu	%xmm7, %xmm8
+	vmovdqu	%xmm8, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm7, %xmm7
+	movq	%xmm7, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A64$3:
@@ -15681,14 +15674,14 @@ L_sha3_512A_A33$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %xmm9
 	movq	24(%rbp,%rcx), %rdx
-	vmovq	%rdx, %xmm10
+	vmovq	%rdx, %xmm7
 	movq	$0, %rdx
 	movzbq	32(%rbp,%rcx), %rax
 	orq 	$1536, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm10, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm7, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15701,19 +15694,19 @@ L_sha3_512A_A33$1:
 L_sha3_512A_A33$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A33$5:
-	vmovdqu	%xmm4, %xmm9
-	movq	%xmm9, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm7
+	movq	%xmm7, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
-	movq	%xmm7, %rdx
-	movq	%rdx, 40(%rsi,%rcx)
+	movq	%xmm7, %r8
+	movq	%r8, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm9
-	vmovdqu	%xmm9, %xmm7
-	vmovdqu	%xmm7, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm9, %xmm9
-	movq	%xmm9, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm7
+	vmovdqu	%xmm7, %xmm8
+	vmovdqu	%xmm8, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm7, %xmm7
+	movq	%xmm7, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A33$3:
@@ -16238,7 +16231,7 @@ L_nttunpack$1:
 	vperm2i128	$32, %ymm5, %ymm2, %ymm0
 	vperm2i128	$49, %ymm5, %ymm2, %ymm2
 	vperm2i128	$32, %ymm7, %ymm3, %ymm6
-	vperm2i128	$49, %ymm7, %ymm3, %ymm7
+	vperm2i128	$49, %ymm7, %ymm3, %ymm9
 	vperm2i128	$32, %ymm4, %ymm1, %ymm5
 	vperm2i128	$49, %ymm4, %ymm1, %ymm1
 	vperm2i128	$32, %ymm15, %ymm8, %ymm10
@@ -16246,13 +16239,13 @@ L_nttunpack$1:
 	vpunpcklqdq	%ymm5, %ymm0, %ymm3
 	vpunpckhqdq	%ymm5, %ymm0, %ymm4
 	vpunpcklqdq	%ymm1, %ymm2, %ymm5
-	vpunpckhqdq	%ymm1, %ymm2, %ymm9
+	vpunpckhqdq	%ymm1, %ymm2, %ymm7
 	vpunpcklqdq	%ymm10, %ymm6, %ymm2
 	vpunpckhqdq	%ymm10, %ymm6, %ymm1
-	vpunpcklqdq	%ymm8, %ymm7, %ymm6
-	vpunpckhqdq	%ymm8, %ymm7, %ymm7
+	vpunpcklqdq	%ymm8, %ymm9, %ymm6
+	vpunpckhqdq	%ymm8, %ymm9, %ymm8
 	vmovsldup	%ymm2, %ymm11
-	vpblendd	$170, %ymm11, %ymm3, %ymm10
+	vpblendd	$170, %ymm11, %ymm3, %ymm9
 	vpsrlq	$32, %ymm3, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
 	vmovsldup	%ymm1, %ymm11
@@ -16263,13 +16256,13 @@ L_nttunpack$1:
 	vpblendd	$170, %ymm11, %ymm5, %ymm1
 	vpsrlq	$32, %ymm5, %ymm5
 	vpblendd	$170, %ymm6, %ymm5, %ymm5
-	vmovsldup	%ymm7, %ymm6
-	vpblendd	$170, %ymm6, %ymm9, %ymm6
-	vpsrlq	$32, %ymm9, %ymm9
-	vpblendd	$170, %ymm7, %ymm9, %ymm7
+	vmovsldup	%ymm8, %ymm6
+	vpblendd	$170, %ymm6, %ymm7, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpblendd	$170, %ymm8, %ymm7, %ymm7
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm10, %ymm0
-	vpsrld	$16, %ymm10, %ymm8
+	vpblendw	$170, %ymm11, %ymm9, %ymm0
+	vpsrld	$16, %ymm9, %ymm8
 	vpblendw	$170, %ymm1, %ymm8, %ymm9
 	vpslld	$16, %ymm5, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -3916,301 +3916,295 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc:
 	movq	%rdi, %rbx
 	movq	%rsi, %r12
 	movq	%rdx, %rbp
-	leaq	18560(%rsp), %rdi
+	movq	%rsp, %rdi
 	movq	$32, %rsi
 	call	__jasmin_syscall_randombytes__
 	movq	%rbp, %mm0
 	movq	%r12, %mm1
-	movq	(%rax), %rcx
-	movq	%rcx, (%rsp)
-	movq	8(%rax), %rcx
-	movq	%rcx, 8(%rsp)
-	movq	16(%rax), %rcx
-	movq	%rcx, 16(%rsp)
-	movq	24(%rax), %rcx
-	movq	%rcx, 24(%rsp)
-	leaq	32(%rsp), %rsi
+	vmovdqu	(%rax), %ymm1
+	vmovdqu	%ymm1, 32(%rsp)
+	leaq	64(%rsp), %rsi
 	call	L_sha3_256A_A1568$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$66:
-	leaq	64(%rsp), %rsi
-	movq	%rsp, %rbp
+	leaq	96(%rsp), %rsi
+	leaq	32(%rsp), %rbp
 	call	L_sha3_512A_A64$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$65:
 	movq	%mm0, %rbp
-	movq	%rsp, %rax
-	leaq	96(%rsp), %rdi
+	leaq	32(%rsp), %rax
+	leaq	128(%rsp), %rdi
 	movq	%rbx, %mm2
 	movq	%rbp, %rcx
-	leaq	2176(%rsp), %rsi
+	leaq	2208(%rsp), %rsi
 	movq	%rcx, %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$64:
-	leaq	2688(%rsp), %rsi
+	leaq	2720(%rsp), %rsi
 	leaq	384(%rcx), %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$63:
-	leaq	3200(%rsp), %rsi
+	leaq	3232(%rsp), %rsi
 	leaq	768(%rcx), %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$62:
-	leaq	3712(%rsp), %rsi
+	leaq	3744(%rsp), %rsi
 	leaq	1152(%rcx), %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$61:
 	movq	1536(%rbp), %rcx
-	movq	%rcx, 18560(%rsp)
+	movq	%rcx, (%rsp)
 	movq	1544(%rbp), %rcx
-	movq	%rcx, 18568(%rsp)
+	movq	%rcx, 8(%rsp)
 	movq	1552(%rbp), %rcx
-	movq	%rcx, 18576(%rsp)
+	movq	%rcx, 16(%rsp)
 	movq	1560(%rbp), %rcx
-	movq	%rcx, 18584(%rsp)
-	leaq	128(%rsp), %rcx
+	movq	%rcx, 24(%rsp)
+	leaq	160(%rsp), %rcx
 	call	L_i_poly_frommsg$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$60:
 	movq	$1, %rcx
-	leaq	10368(%rsp), %rax
-	leaq	18560(%rsp), %rdx
+	leaq	10400(%rsp), %rax
+	movq	%rsp, %rdx
 	leaq	-2168(%rsp), %rsp
 	call	L_gen_matrix_avx2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$59:
 	leaq	2168(%rsp), %rsp
 	movb	$0, %r9b
-	leaq	4224(%rsp), %rax
-	leaq	4736(%rsp), %rcx
-	leaq	5248(%rsp), %rdx
-	leaq	5760(%rsp), %r8
+	leaq	4256(%rsp), %rax
+	leaq	4768(%rsp), %rcx
+	leaq	5280(%rsp), %rdx
+	leaq	5792(%rsp), %r8
 	leaq	-600(%rsp), %rsp
 	call	L_poly_getnoise_eta1_4x$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$58:
 	leaq	600(%rsp), %rsp
 	movb	$4, %r9b
-	leaq	6272(%rsp), %rax
-	leaq	6784(%rsp), %rcx
-	leaq	7296(%rsp), %rdx
-	leaq	7808(%rsp), %r8
+	leaq	6304(%rsp), %rax
+	leaq	6816(%rsp), %rcx
+	leaq	7328(%rsp), %rdx
+	leaq	7840(%rsp), %r8
 	leaq	-600(%rsp), %rsp
 	call	L_poly_getnoise_eta1_4x$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$57:
 	leaq	600(%rsp), %rsp
 	movb	$8, %al
-	leaq	640(%rsp), %rcx
+	leaq	672(%rsp), %rcx
 	leaq	-184(%rsp), %rsp
 	call	L_poly_getnoise_eta2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$56:
 	leaq	184(%rsp), %rsp
-	leaq	4224(%rsp), %rcx
+	leaq	4256(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$55:
-	leaq	4736(%rsp), %rcx
+	leaq	4768(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$54:
-	leaq	5248(%rsp), %rcx
+	leaq	5280(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$53:
-	leaq	5760(%rsp), %rcx
+	leaq	5792(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$52:
-	leaq	8320(%rsp), %rcx
-	leaq	10368(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	10400(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$51:
-	leaq	1152(%rsp), %rcx
-	leaq	10880(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	10912(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$50:
-	leaq	8320(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$49:
-	leaq	1152(%rsp), %rcx
-	leaq	11392(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	11424(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$48:
-	leaq	8320(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$47:
-	leaq	1152(%rsp), %rcx
-	leaq	11904(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	11936(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$46:
-	leaq	8320(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$45:
-	leaq	8832(%rsp), %rcx
-	leaq	12416(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	12448(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$44:
-	leaq	1152(%rsp), %rcx
-	leaq	12928(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	12960(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$43:
-	leaq	8832(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$42:
-	leaq	1152(%rsp), %rcx
-	leaq	13440(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	13472(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$41:
-	leaq	8832(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$40:
-	leaq	1152(%rsp), %rcx
-	leaq	13952(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	13984(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$39:
-	leaq	8832(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$38:
-	leaq	9344(%rsp), %rcx
-	leaq	14464(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	14496(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$37:
-	leaq	1152(%rsp), %rcx
-	leaq	14976(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	15008(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$36:
-	leaq	9344(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$35:
-	leaq	1152(%rsp), %rcx
-	leaq	15488(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	15520(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$34:
-	leaq	9344(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$33:
-	leaq	1152(%rsp), %rcx
-	leaq	16000(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	16032(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$32:
-	leaq	9344(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$31:
-	leaq	9856(%rsp), %rcx
-	leaq	16512(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	16544(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$30:
-	leaq	1152(%rsp), %rcx
-	leaq	17024(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	17056(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$29:
-	leaq	9856(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$28:
-	leaq	1152(%rsp), %rcx
-	leaq	17536(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	17568(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$27:
-	leaq	9856(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$26:
-	leaq	1152(%rsp), %rcx
-	leaq	18048(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	18080(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$25:
-	leaq	9856(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$24:
-	leaq	1152(%rsp), %rcx
-	leaq	2176(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	2208(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$23:
-	leaq	1664(%rsp), %rcx
-	leaq	2688(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1696(%rsp), %rcx
+	leaq	2720(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$22:
-	leaq	1152(%rsp), %rcx
-	leaq	1664(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	1696(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$21:
-	leaq	1664(%rsp), %rcx
-	leaq	3200(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1696(%rsp), %rcx
+	leaq	3232(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$20:
-	leaq	1152(%rsp), %rcx
-	leaq	1664(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	1696(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$19:
-	leaq	1664(%rsp), %rcx
-	leaq	3712(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1696(%rsp), %rcx
+	leaq	3744(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$18:
-	leaq	1152(%rsp), %rcx
-	leaq	1664(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	1696(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$17:
-	leaq	8320(%rsp), %rcx
+	leaq	8352(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$16:
-	leaq	8832(%rsp), %rcx
+	leaq	8864(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$15:
-	leaq	9344(%rsp), %rcx
+	leaq	9376(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$14:
-	leaq	9856(%rsp), %rcx
+	leaq	9888(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$13:
-	leaq	1152(%rsp), %rcx
+	leaq	1184(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$12:
-	leaq	8320(%rsp), %rcx
-	leaq	6272(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	6304(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$11:
-	leaq	8832(%rsp), %rcx
-	leaq	6784(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	6816(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$10:
-	leaq	9344(%rsp), %rcx
-	leaq	7296(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	7328(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$9:
-	leaq	9856(%rsp), %rcx
-	leaq	7808(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	7840(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$8:
-	leaq	1152(%rsp), %rcx
-	leaq	640(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	672(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$7:
-	leaq	1152(%rsp), %rcx
-	leaq	128(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	160(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
-	leaq	8320(%rsp), %rax
+	leaq	8352(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4309,7 +4303,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	8832(%rsp), %rax
+	leaq	8864(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4408,7 +4402,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	9344(%rsp), %rax
+	leaq	9376(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4507,7 +4501,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	9856(%rsp), %rax
+	leaq	9888(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4606,7 +4600,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	1152(%rsp), %rax
+	leaq	1184(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4707,16 +4701,16 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vmovdqu	%ymm1, 480(%rax)
 	movq	%mm2, %rbx
 	movq	%rbx, %rax
-	leaq	8320(%rsp), %rcx
+	leaq	8352(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$5:
-	leaq	8832(%rsp), %rcx
+	leaq	8864(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$4:
-	leaq	9344(%rsp), %rcx
+	leaq	9376(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$3:
-	leaq	9856(%rsp), %rcx
+	leaq	9888(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vmovdqu	glob_data + 1120(%rip), %ymm0
@@ -4728,7 +4722,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpbroadcastq	glob_data + 4960(%rip), %ymm6
 	vmovdqu	glob_data + 160(%rip), %ymm7
 	vmovdqu	glob_data + 128(%rip), %ymm8
-	vmovdqu	8320(%rsp), %ymm9
+	vmovdqu	8352(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4751,7 +4745,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, (%rax)
 	movq	%xmm9, 16(%rax)
-	vmovdqu	8352(%rsp), %ymm9
+	vmovdqu	8384(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4774,7 +4768,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 22(%rax)
 	movq	%xmm9, 38(%rax)
-	vmovdqu	8384(%rsp), %ymm9
+	vmovdqu	8416(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4797,7 +4791,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 44(%rax)
 	movq	%xmm9, 60(%rax)
-	vmovdqu	8416(%rsp), %ymm9
+	vmovdqu	8448(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4820,7 +4814,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 66(%rax)
 	movq	%xmm9, 82(%rax)
-	vmovdqu	8448(%rsp), %ymm9
+	vmovdqu	8480(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4843,7 +4837,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 88(%rax)
 	movq	%xmm9, 104(%rax)
-	vmovdqu	8480(%rsp), %ymm9
+	vmovdqu	8512(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4866,7 +4860,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 110(%rax)
 	movq	%xmm9, 126(%rax)
-	vmovdqu	8512(%rsp), %ymm9
+	vmovdqu	8544(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4889,7 +4883,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 132(%rax)
 	movq	%xmm9, 148(%rax)
-	vmovdqu	8544(%rsp), %ymm9
+	vmovdqu	8576(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4912,7 +4906,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 154(%rax)
 	movq	%xmm9, 170(%rax)
-	vmovdqu	8576(%rsp), %ymm9
+	vmovdqu	8608(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4935,7 +4929,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 176(%rax)
 	movq	%xmm9, 192(%rax)
-	vmovdqu	8608(%rsp), %ymm9
+	vmovdqu	8640(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4958,7 +4952,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 198(%rax)
 	movq	%xmm9, 214(%rax)
-	vmovdqu	8640(%rsp), %ymm9
+	vmovdqu	8672(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4981,7 +4975,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 220(%rax)
 	movq	%xmm9, 236(%rax)
-	vmovdqu	8672(%rsp), %ymm9
+	vmovdqu	8704(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5004,7 +4998,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 242(%rax)
 	movq	%xmm9, 258(%rax)
-	vmovdqu	8704(%rsp), %ymm9
+	vmovdqu	8736(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5027,7 +5021,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 264(%rax)
 	movq	%xmm9, 280(%rax)
-	vmovdqu	8736(%rsp), %ymm9
+	vmovdqu	8768(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5050,7 +5044,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 286(%rax)
 	movq	%xmm9, 302(%rax)
-	vmovdqu	8768(%rsp), %ymm9
+	vmovdqu	8800(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5073,7 +5067,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 308(%rax)
 	movq	%xmm9, 324(%rax)
-	vmovdqu	8800(%rsp), %ymm9
+	vmovdqu	8832(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5096,7 +5090,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 330(%rax)
 	movq	%xmm9, 346(%rax)
-	vmovdqu	8832(%rsp), %ymm9
+	vmovdqu	8864(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5119,7 +5113,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 352(%rax)
 	movq	%xmm9, 368(%rax)
-	vmovdqu	8864(%rsp), %ymm9
+	vmovdqu	8896(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5142,7 +5136,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 374(%rax)
 	movq	%xmm9, 390(%rax)
-	vmovdqu	8896(%rsp), %ymm9
+	vmovdqu	8928(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5165,7 +5159,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 396(%rax)
 	movq	%xmm9, 412(%rax)
-	vmovdqu	8928(%rsp), %ymm9
+	vmovdqu	8960(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5188,7 +5182,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 418(%rax)
 	movq	%xmm9, 434(%rax)
-	vmovdqu	8960(%rsp), %ymm9
+	vmovdqu	8992(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5211,7 +5205,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 440(%rax)
 	movq	%xmm9, 456(%rax)
-	vmovdqu	8992(%rsp), %ymm9
+	vmovdqu	9024(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5234,7 +5228,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 462(%rax)
 	movq	%xmm9, 478(%rax)
-	vmovdqu	9024(%rsp), %ymm9
+	vmovdqu	9056(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5257,7 +5251,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 484(%rax)
 	movq	%xmm9, 500(%rax)
-	vmovdqu	9056(%rsp), %ymm9
+	vmovdqu	9088(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5280,7 +5274,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 506(%rax)
 	movq	%xmm9, 522(%rax)
-	vmovdqu	9088(%rsp), %ymm9
+	vmovdqu	9120(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5303,7 +5297,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 528(%rax)
 	movq	%xmm9, 544(%rax)
-	vmovdqu	9120(%rsp), %ymm9
+	vmovdqu	9152(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5326,7 +5320,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 550(%rax)
 	movq	%xmm9, 566(%rax)
-	vmovdqu	9152(%rsp), %ymm9
+	vmovdqu	9184(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5349,7 +5343,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 572(%rax)
 	movq	%xmm9, 588(%rax)
-	vmovdqu	9184(%rsp), %ymm9
+	vmovdqu	9216(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5372,7 +5366,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 594(%rax)
 	movq	%xmm9, 610(%rax)
-	vmovdqu	9216(%rsp), %ymm9
+	vmovdqu	9248(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5395,7 +5389,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 616(%rax)
 	movq	%xmm9, 632(%rax)
-	vmovdqu	9248(%rsp), %ymm9
+	vmovdqu	9280(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5418,7 +5412,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 638(%rax)
 	movq	%xmm9, 654(%rax)
-	vmovdqu	9280(%rsp), %ymm9
+	vmovdqu	9312(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5441,7 +5435,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 660(%rax)
 	movq	%xmm9, 676(%rax)
-	vmovdqu	9312(%rsp), %ymm9
+	vmovdqu	9344(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5464,7 +5458,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 682(%rax)
 	movq	%xmm9, 698(%rax)
-	vmovdqu	9344(%rsp), %ymm9
+	vmovdqu	9376(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5487,7 +5481,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 704(%rax)
 	movq	%xmm9, 720(%rax)
-	vmovdqu	9376(%rsp), %ymm9
+	vmovdqu	9408(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5510,7 +5504,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 726(%rax)
 	movq	%xmm9, 742(%rax)
-	vmovdqu	9408(%rsp), %ymm9
+	vmovdqu	9440(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5533,7 +5527,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 748(%rax)
 	movq	%xmm9, 764(%rax)
-	vmovdqu	9440(%rsp), %ymm9
+	vmovdqu	9472(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5556,7 +5550,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 770(%rax)
 	movq	%xmm9, 786(%rax)
-	vmovdqu	9472(%rsp), %ymm9
+	vmovdqu	9504(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5579,7 +5573,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 792(%rax)
 	movq	%xmm9, 808(%rax)
-	vmovdqu	9504(%rsp), %ymm9
+	vmovdqu	9536(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5602,7 +5596,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 814(%rax)
 	movq	%xmm9, 830(%rax)
-	vmovdqu	9536(%rsp), %ymm9
+	vmovdqu	9568(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5625,7 +5619,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 836(%rax)
 	movq	%xmm9, 852(%rax)
-	vmovdqu	9568(%rsp), %ymm9
+	vmovdqu	9600(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5648,7 +5642,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 858(%rax)
 	movq	%xmm9, 874(%rax)
-	vmovdqu	9600(%rsp), %ymm9
+	vmovdqu	9632(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5671,7 +5665,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 880(%rax)
 	movq	%xmm9, 896(%rax)
-	vmovdqu	9632(%rsp), %ymm9
+	vmovdqu	9664(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5694,7 +5688,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 902(%rax)
 	movq	%xmm9, 918(%rax)
-	vmovdqu	9664(%rsp), %ymm9
+	vmovdqu	9696(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5717,7 +5711,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 924(%rax)
 	movq	%xmm9, 940(%rax)
-	vmovdqu	9696(%rsp), %ymm9
+	vmovdqu	9728(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5740,7 +5734,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 946(%rax)
 	movq	%xmm9, 962(%rax)
-	vmovdqu	9728(%rsp), %ymm9
+	vmovdqu	9760(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5763,7 +5757,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 968(%rax)
 	movq	%xmm9, 984(%rax)
-	vmovdqu	9760(%rsp), %ymm9
+	vmovdqu	9792(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5786,7 +5780,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 990(%rax)
 	movq	%xmm9, 1006(%rax)
-	vmovdqu	9792(%rsp), %ymm9
+	vmovdqu	9824(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5809,7 +5803,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1012(%rax)
 	movq	%xmm9, 1028(%rax)
-	vmovdqu	9824(%rsp), %ymm9
+	vmovdqu	9856(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5832,7 +5826,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1034(%rax)
 	movq	%xmm9, 1050(%rax)
-	vmovdqu	9856(%rsp), %ymm9
+	vmovdqu	9888(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5855,7 +5849,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1056(%rax)
 	movq	%xmm9, 1072(%rax)
-	vmovdqu	9888(%rsp), %ymm9
+	vmovdqu	9920(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5878,7 +5872,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1078(%rax)
 	movq	%xmm9, 1094(%rax)
-	vmovdqu	9920(%rsp), %ymm9
+	vmovdqu	9952(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5901,7 +5895,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1100(%rax)
 	movq	%xmm9, 1116(%rax)
-	vmovdqu	9952(%rsp), %ymm9
+	vmovdqu	9984(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5924,7 +5918,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1122(%rax)
 	movq	%xmm9, 1138(%rax)
-	vmovdqu	9984(%rsp), %ymm9
+	vmovdqu	10016(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5947,7 +5941,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1144(%rax)
 	movq	%xmm9, 1160(%rax)
-	vmovdqu	10016(%rsp), %ymm9
+	vmovdqu	10048(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5970,7 +5964,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1166(%rax)
 	movq	%xmm9, 1182(%rax)
-	vmovdqu	10048(%rsp), %ymm9
+	vmovdqu	10080(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5993,7 +5987,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1188(%rax)
 	movq	%xmm9, 1204(%rax)
-	vmovdqu	10080(%rsp), %ymm9
+	vmovdqu	10112(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6016,7 +6010,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1210(%rax)
 	movq	%xmm9, 1226(%rax)
-	vmovdqu	10112(%rsp), %ymm9
+	vmovdqu	10144(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6039,7 +6033,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1232(%rax)
 	movq	%xmm9, 1248(%rax)
-	vmovdqu	10144(%rsp), %ymm9
+	vmovdqu	10176(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6062,7 +6056,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1254(%rax)
 	movq	%xmm9, 1270(%rax)
-	vmovdqu	10176(%rsp), %ymm9
+	vmovdqu	10208(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6085,7 +6079,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1276(%rax)
 	movq	%xmm9, 1292(%rax)
-	vmovdqu	10208(%rsp), %ymm9
+	vmovdqu	10240(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6108,7 +6102,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1298(%rax)
 	movq	%xmm9, 1314(%rax)
-	vmovdqu	10240(%rsp), %ymm9
+	vmovdqu	10272(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6131,7 +6125,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1320(%rax)
 	movq	%xmm9, 1336(%rax)
-	vmovdqu	10272(%rsp), %ymm9
+	vmovdqu	10304(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6154,7 +6148,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1342(%rax)
 	movq	%xmm9, 1358(%rax)
-	vmovdqu	10304(%rsp), %ymm9
+	vmovdqu	10336(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6177,7 +6171,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1364(%rax)
 	movq	%xmm9, 1380(%rax)
-	vmovdqu	10336(%rsp), %ymm9
+	vmovdqu	10368(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6201,7 +6195,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vmovdqu	%xmm2, 1386(%rax)
 	movq	%xmm3, 1402(%rax)
 	leaq	1408(%rbx), %rax
-	leaq	1152(%rsp), %rcx
+	leaq	1184(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$1:
 	vmovdqu	glob_data + 1120(%rip), %ymm0
@@ -6364,7 +6358,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$1:
 	vmovdqu	%xmm2, 140(%rax)
 	movd	%xmm3, 156(%rax)
 	movq	%mm1, %rsi
-	vmovdqu	64(%rsp), %ymm0
+	vmovdqu	96(%rsp), %ymm0
 	vmovdqu	%ymm0, (%rsi)
 	xorl	%eax, %eax
 	movq	18592(%rsp), %rbx
@@ -7506,14 +7500,8 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand:
 	movq	%rdx, %rbp
 	movq	%rbp, %mm0
 	movq	%rsi, %mm1
-	movq	(%rcx), %rax
-	movq	%rax, (%rsp)
-	movq	8(%rcx), %rax
-	movq	%rax, 8(%rsp)
-	movq	16(%rcx), %rax
-	movq	%rax, 16(%rsp)
-	movq	24(%rcx), %rax
-	movq	%rax, 24(%rsp)
+	vmovdqu	(%rcx), %ymm1
+	vmovdqu	%ymm1, (%rsp)
 	leaq	32(%rsp), %rsi
 	call	L_sha3_256A_A1568$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand$66:

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -856,15 +856,8 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_dec$68:
 	leaq	1152(%rsp), %rcx
 	call	L_i_poly_tomsg$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_dec$67:
-	leaq	3104(%rdx), %rax
-	movq	(%rax), %rcx
-	movq	%rcx, 32(%rsp)
-	movq	8(%rax), %rcx
-	movq	%rcx, 40(%rsp)
-	movq	16(%rax), %rcx
-	movq	%rcx, 48(%rsp)
-	movq	24(%rax), %rcx
-	movq	%rcx, 56(%rsp)
+	vmovdqu	3104(%rdx), %ymm0
+	vmovdqu	%ymm0, 32(%rsp)
 	leaq	64(%rsp), %rsi
 	movq	%rsp, %rbp
 	call	L_sha3_512A_A64$1
@@ -11393,12 +11386,12 @@ L_gen_matrix_buf_rejection$14:
 	cmovnbe	%r12, %r11
 	vmovdqu	%xmm4, (%r9,%rbp,2)
 L_gen_matrix_buf_rejection$15:
-	vextracti128	$1, %ymm3, %xmm4
+	vextracti128	$1, %ymm3, %xmm3
 	cmpq	$248, %r13
 	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	movq	%xmm4, %r12
+	movq	%xmm3, %r12
 	cmpq	$252, %r13
 	jbe 	L_gen_matrix_buf_rejection$12
 	movq	$-1, %rbp
@@ -11408,7 +11401,7 @@ L_gen_matrix_buf_rejection$12:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
 	movq	%r12, (%r9,%r13,2)
-	vpextrq	$1, %xmm4, %r12
+	vpextrq	$1, %xmm3, %r12
 	addq	$4, %r13
 L_gen_matrix_buf_rejection$13:
 	cmpq	$254, %r13
@@ -11437,7 +11430,7 @@ L_gen_matrix_buf_rejection$9:
 L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
-	vmovdqu	%xmm4, (%r9,%r13,2)
+	vmovdqu	%xmm3, (%r9,%r13,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r14, %rbp
 	movq	8(%rsp), %r13
@@ -11862,13 +11855,13 @@ L_i_poly_tobytes$2:
 	vperm2i128	$32, %ymm2, %ymm7, %ymm4
 	vperm2i128	$49, %ymm2, %ymm7, %ymm0
 	vperm2i128	$32, %ymm1, %ymm5, %ymm2
-	vperm2i128	$49, %ymm1, %ymm5, %ymm1
+	vperm2i128	$49, %ymm1, %ymm5, %ymm7
 	vmovdqu	%ymm11, 192(%rsi)
 	vmovdqu	%ymm4, 224(%rsi)
 	vmovdqu	%ymm2, 256(%rsi)
 	vmovdqu	%ymm6, 288(%rsi)
 	vmovdqu	%ymm0, 320(%rsi)
-	vmovdqu	%ymm1, 352(%rsi)
+	vmovdqu	%ymm7, 352(%rsi)
 	ret
 L_poly_sub$1:
 	vmovdqu	(%rsi), %ymm2
@@ -12013,27 +12006,26 @@ L_poly_ntt$1:
 	vpsubw	%ymm5, %ymm1, %ymm12
 	vpaddw	%ymm1, %ymm5, %ymm1
 	vpaddw	%ymm9, %ymm2, %ymm5
-	vpsubw	%ymm2, %ymm8, %ymm9
-	vpaddw	%ymm13, %ymm4, %ymm8
+	vpsubw	%ymm2, %ymm8, %ymm8
+	vpaddw	%ymm13, %ymm4, %ymm9
 	vpsubw	%ymm4, %ymm6, %ymm6
 	vpaddw	%ymm12, %ymm10, %ymm4
 	vpsubw	%ymm10, %ymm1, %ymm12
 	vpaddw	%ymm7, %ymm11, %ymm15
 	vpsubw	%ymm11, %ymm3, %ymm13
 	vmovdqu	%ymm5, 384(%rcx)
-	vmovdqu	%ymm8, 416(%rcx)
+	vmovdqu	%ymm9, 416(%rcx)
 	vmovdqu	%ymm4, 448(%rcx)
 	vmovdqu	%ymm15, 480(%rcx)
 	vpbroadcastd	glob_data + 2024(%rip), %ymm2
 	vpbroadcastd	glob_data + 2028(%rip), %ymm4
-	vmovdqu	%ymm9, %ymm11
 	vmovdqu	%ymm6, %ymm10
 	vmovdqu	(%rcx), %ymm9
 	vmovdqu	32(%rcx), %ymm6
 	vmovdqu	64(%rcx), %ymm7
 	vmovdqu	96(%rcx), %ymm5
-	vpmullw	%ymm11, %ymm2, %ymm15
-	vpmulhw	%ymm11, %ymm4, %ymm3
+	vpmullw	%ymm8, %ymm2, %ymm15
+	vpmulhw	%ymm8, %ymm4, %ymm3
 	vpmullw	%ymm10, %ymm2, %ymm11
 	vpmulhw	%ymm10, %ymm4, %ymm10
 	vpmullw	%ymm12, %ymm2, %ymm1
@@ -12303,7 +12295,7 @@ L_poly_ntt$1:
 	vmovdqu	%ymm15, 224(%rcx)
 	vpbroadcastd	glob_data + 2416(%rip), %ymm2
 	vpbroadcastd	glob_data + 2420(%rip), %ymm6
-	vmovdqu	384(%rcx), %ymm15
+	vmovdqu	384(%rcx), %ymm8
 	vmovdqu	416(%rcx), %ymm13
 	vmovdqu	448(%rcx), %ymm5
 	vmovdqu	480(%rcx), %ymm7
@@ -12311,8 +12303,8 @@ L_poly_ntt$1:
 	vmovdqu	288(%rcx), %ymm3
 	vmovdqu	320(%rcx), %ymm12
 	vmovdqu	352(%rcx), %ymm4
-	vpmullw	%ymm15, %ymm2, %ymm11
-	vpmulhw	%ymm15, %ymm6, %ymm10
+	vpmullw	%ymm8, %ymm2, %ymm11
+	vpmulhw	%ymm8, %ymm6, %ymm10
 	vpmullw	%ymm13, %ymm2, %ymm8
 	vpmulhw	%ymm13, %ymm6, %ymm15
 	vpmullw	%ymm5, %ymm2, %ymm1
@@ -12829,8 +12821,8 @@ L_poly_invntt$1:
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm9
-	vmovdqu	%ymm9, (%rcx)
+	vpsubw	%ymm5, %ymm9, %ymm1
+	vmovdqu	%ymm1, (%rcx)
 	vmovdqu	%ymm10, 32(%rcx)
 	vmovdqu	%ymm2, 64(%rcx)
 	vmovdqu	%ymm3, 96(%rcx)
@@ -12866,11 +12858,11 @@ L_poly_invntt$1:
 	vpmulhw	%ymm7, %ymm2, %ymm7
 	vpmulhw	%ymm8, %ymm5, %ymm2
 	vpmulhw	%ymm10, %ymm5, %ymm10
-	vpmulhw	%ymm9, %ymm0, %ymm9
+	vpmulhw	%ymm9, %ymm0, %ymm8
 	vpmulhw	%ymm13, %ymm0, %ymm13
 	vpmulhw	%ymm12, %ymm0, %ymm5
 	vpmulhw	%ymm1, %ymm0, %ymm1
-	vpsubw	%ymm9, %ymm15, %ymm12
+	vpsubw	%ymm8, %ymm15, %ymm12
 	vpsubw	%ymm13, %ymm7, %ymm8
 	vpsubw	%ymm5, %ymm2, %ymm9
 	vpsubw	%ymm1, %ymm10, %ymm7
@@ -13084,7 +13076,7 @@ L_poly_invntt$1:
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm9
+	vpsubw	%ymm5, %ymm9, %ymm7
 	vmovdqu	%ymm6, 384(%rcx)
 	vmovdqu	%ymm8, 416(%rcx)
 	vmovdqu	%ymm4, 448(%rcx)
@@ -13093,15 +13085,14 @@ L_poly_invntt$1:
 	vpbroadcastd	glob_data + 2004(%rip), %ymm5
 	vmovdqu	%ymm3, %ymm15
 	vmovdqu	%ymm2, %ymm4
-	vmovdqu	%ymm9, %ymm2
 	vmovdqu	(%rcx), %ymm13
 	vmovdqu	32(%rcx), %ymm3
 	vmovdqu	64(%rcx), %ymm6
 	vmovdqu	96(%rcx), %ymm8
-	vpsubw	%ymm2, %ymm13, %ymm14
+	vpsubw	%ymm7, %ymm13, %ymm14
 	vpsubw	%ymm10, %ymm3, %ymm9
 	vpsubw	%ymm4, %ymm6, %ymm12
-	vpaddw	%ymm13, %ymm2, %ymm2
+	vpaddw	%ymm13, %ymm7, %ymm2
 	vpaddw	%ymm3, %ymm10, %ymm3
 	vpmullw	%ymm14, %ymm1, %ymm11
 	vpaddw	%ymm6, %ymm4, %ymm6
@@ -14077,9 +14068,9 @@ L_poly_frommont$1:
 	vpmulhw	%ymm0, %ymm3, %ymm3
 	vpsubw	%ymm3, %ymm4, %ymm5
 	vmovdqu	%ymm5, 416(%rax)
-	vmovdqu	448(%rax), %ymm5
-	vpmulhw	%ymm2, %ymm5, %ymm4
-	vpmullw	%ymm2, %ymm5, %ymm3
+	vmovdqu	448(%rax), %ymm3
+	vpmulhw	%ymm2, %ymm3, %ymm4
+	vpmullw	%ymm2, %ymm3, %ymm3
 	vpmullw	%ymm1, %ymm3, %ymm3
 	vpmulhw	%ymm0, %ymm3, %ymm3
 	vpsubw	%ymm3, %ymm4, %ymm5
@@ -14174,19 +14165,19 @@ L_i_poly_frombytes$1:
 	vmovdqu	352(%r9), %ymm7
 	vperm2i128	$32, %ymm1, %ymm2, %ymm8
 	vperm2i128	$49, %ymm1, %ymm2, %ymm6
-	vperm2i128	$32, %ymm5, %ymm3, %ymm9
-	vperm2i128	$49, %ymm5, %ymm3, %ymm1
+	vperm2i128	$32, %ymm5, %ymm3, %ymm1
+	vperm2i128	$49, %ymm5, %ymm3, %ymm2
 	vperm2i128	$32, %ymm7, %ymm4, %ymm5
 	vperm2i128	$49, %ymm7, %ymm4, %ymm7
-	vpunpcklqdq	%ymm1, %ymm8, %ymm10
-	vpunpckhqdq	%ymm1, %ymm8, %ymm2
+	vpunpcklqdq	%ymm2, %ymm8, %ymm9
+	vpunpckhqdq	%ymm2, %ymm8, %ymm2
 	vpunpcklqdq	%ymm5, %ymm6, %ymm3
 	vpunpckhqdq	%ymm5, %ymm6, %ymm5
-	vpunpcklqdq	%ymm7, %ymm9, %ymm6
-	vpunpckhqdq	%ymm7, %ymm9, %ymm1
+	vpunpcklqdq	%ymm7, %ymm1, %ymm6
+	vpunpckhqdq	%ymm7, %ymm1, %ymm1
 	vmovsldup	%ymm5, %ymm11
-	vpblendd	$170, %ymm11, %ymm10, %ymm4
-	vpsrlq	$32, %ymm10, %ymm7
+	vpblendd	$170, %ymm11, %ymm9, %ymm4
+	vpsrlq	$32, %ymm9, %ymm7
 	vpblendd	$170, %ymm5, %ymm7, %ymm5
 	vmovsldup	%ymm6, %ymm11
 	vpblendd	$170, %ymm11, %ymm2, %ymm7
@@ -14639,9 +14630,9 @@ L_poly_basemul$1:
 	vpsubw	%ymm5, %ymm7, %ymm5
 	vpmullw	%ymm1, %ymm8, %ymm6
 	vpmulhw	%ymm0, %ymm6, %ymm0
-	vpsubw	%ymm0, %ymm4, %ymm0
+	vpsubw	%ymm0, %ymm4, %ymm4
 	vmovdqu	%ymm5, 448(%rcx)
-	vmovdqu	%ymm0, 480(%rcx)
+	vmovdqu	%ymm4, 480(%rcx)
 	ret
 L_poly_csubq$1:
 	vmovdqu	glob_data + 1184(%rip), %ymm0
@@ -14817,8 +14808,8 @@ L_shake256_A32__A1600$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
@@ -14859,8 +14850,8 @@ L_shake256_A32__A1600$9:
 	movq	$0, %rdx
 	jmp 	L_shake256_A32__A1600$6
 L_shake256_A32__A1600$7:
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -14902,8 +14893,8 @@ L_shake256_A32__A1600$8:
 L_shake256_A32__A1600$6:
 	cmpq	$10, %rdx
 	jb  	L_shake256_A32__A1600$7
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
@@ -14982,8 +14973,8 @@ L_shake256_A32__A1600$3:
 	call	L_keccakf1600_avx2$1
 L_shake256_A32__A1600$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm7
-	vmovdqu	%xmm7, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm4
+	vmovdqu	%xmm4, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -14996,8 +14987,8 @@ L_sha3_256A_A1568$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15038,8 +15029,8 @@ L_sha3_256A_A1568$9:
 	movq	$0, %rax
 	jmp 	L_sha3_256A_A1568$6
 L_sha3_256A_A1568$7:
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15081,8 +15072,8 @@ L_sha3_256A_A1568$8:
 L_sha3_256A_A1568$6:
 	cmpq	$10, %rax
 	jb  	L_sha3_256A_A1568$7
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15161,8 +15152,8 @@ L_sha3_256A_A1568$3:
 	call	L_keccakf1600_avx2$1
 L_sha3_256A_A1568$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm7
-	vmovdqu	%xmm7, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm4
+	vmovdqu	%xmm4, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -15380,8 +15371,8 @@ L_shake128x4_absorb_A32_A2$2:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %r9
 	shlq	$63, %r9
-	vmovq	%r9, %xmm7
-	vpbroadcastq	%xmm7, %ymm8
+	vmovq	%r9, %xmm4
+	vpbroadcastq	%xmm4, %ymm8
 	vpxor	640(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 640(%r8)
 	ret
@@ -15451,8 +15442,8 @@ L_shake256x4_A128__A32_A1$7:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %rcx
 	shlq	$63, %rcx
-	vmovq	%rcx, %xmm7
-	vpbroadcastq	%xmm7, %ymm8
+	vmovq	%rcx, %xmm4
+	vpbroadcastq	%xmm4, %ymm8
 	vpxor	512(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 512(%r8)
 	movq	$0, %rcx
@@ -15597,8 +15588,8 @@ L_sha3_512A_A64$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15686,8 +15677,8 @@ L_sha3_512A_A33$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %xmm9
 	movq	24(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm10
@@ -16213,9 +16204,9 @@ L_nttunpack$1:
 	vpsrlq	$32, %ymm11, %ymm9
 	vpblendd	$170, %ymm5, %ymm9, %ymm5
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm4, %ymm9
-	vpsrld	$16, %ymm4, %ymm10
-	vpblendw	$170, %ymm1, %ymm10, %ymm0
+	vpblendw	$170, %ymm11, %ymm4, %ymm0
+	vpsrld	$16, %ymm4, %ymm9
+	vpblendw	$170, %ymm1, %ymm9, %ymm9
 	vpslld	$16, %ymm6, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
 	vpsrld	$16, %ymm2, %ymm10
@@ -16228,76 +16219,76 @@ L_nttunpack$1:
 	vpblendw	$170, %ymm6, %ymm7, %ymm3
 	vpsrld	$16, %ymm7, %ymm7
 	vpblendw	$170, %ymm5, %ymm7, %ymm15
-	vmovdqu	%ymm9, (%rcx)
-	vmovdqu	%ymm0, 32(%rcx)
+	vmovdqu	%ymm0, (%rcx)
+	vmovdqu	%ymm9, 32(%rcx)
 	vmovdqu	%ymm1, 64(%rcx)
 	vmovdqu	%ymm13, 96(%rcx)
 	vmovdqu	%ymm2, 128(%rcx)
 	vmovdqu	%ymm4, 160(%rcx)
 	vmovdqu	%ymm3, 192(%rcx)
 	vmovdqu	%ymm15, 224(%rcx)
-	vmovdqu	256(%rcx), %ymm3
-	vmovdqu	288(%rcx), %ymm5
+	vmovdqu	256(%rcx), %ymm2
+	vmovdqu	288(%rcx), %ymm3
 	vmovdqu	320(%rcx), %ymm1
 	vmovdqu	352(%rcx), %ymm8
-	vmovdqu	384(%rcx), %ymm6
+	vmovdqu	384(%rcx), %ymm5
 	vmovdqu	416(%rcx), %ymm7
-	vmovdqu	448(%rcx), %ymm12
+	vmovdqu	448(%rcx), %ymm4
 	vmovdqu	480(%rcx), %ymm15
-	vperm2i128	$32, %ymm6, %ymm3, %ymm2
-	vperm2i128	$49, %ymm6, %ymm3, %ymm4
-	vperm2i128	$32, %ymm7, %ymm5, %ymm6
-	vperm2i128	$49, %ymm7, %ymm5, %ymm3
-	vperm2i128	$32, %ymm12, %ymm1, %ymm7
-	vperm2i128	$49, %ymm12, %ymm1, %ymm1
+	vperm2i128	$32, %ymm5, %ymm2, %ymm0
+	vperm2i128	$49, %ymm5, %ymm2, %ymm2
+	vperm2i128	$32, %ymm7, %ymm3, %ymm6
+	vperm2i128	$49, %ymm7, %ymm3, %ymm7
+	vperm2i128	$32, %ymm4, %ymm1, %ymm5
+	vperm2i128	$49, %ymm4, %ymm1, %ymm1
 	vperm2i128	$32, %ymm15, %ymm8, %ymm10
 	vperm2i128	$49, %ymm15, %ymm8, %ymm8
-	vpunpcklqdq	%ymm7, %ymm2, %ymm5
-	vpunpckhqdq	%ymm7, %ymm2, %ymm7
-	vpunpcklqdq	%ymm1, %ymm4, %ymm9
-	vpunpckhqdq	%ymm1, %ymm4, %ymm4
+	vpunpcklqdq	%ymm5, %ymm0, %ymm3
+	vpunpckhqdq	%ymm5, %ymm0, %ymm4
+	vpunpcklqdq	%ymm1, %ymm2, %ymm5
+	vpunpckhqdq	%ymm1, %ymm2, %ymm9
 	vpunpcklqdq	%ymm10, %ymm6, %ymm2
 	vpunpckhqdq	%ymm10, %ymm6, %ymm1
-	vpunpcklqdq	%ymm8, %ymm3, %ymm6
-	vpunpckhqdq	%ymm8, %ymm3, %ymm8
+	vpunpcklqdq	%ymm8, %ymm7, %ymm6
+	vpunpckhqdq	%ymm8, %ymm7, %ymm7
 	vmovsldup	%ymm2, %ymm11
-	vpblendd	$170, %ymm11, %ymm5, %ymm10
-	vpsrlq	$32, %ymm5, %ymm3
+	vpblendd	$170, %ymm11, %ymm3, %ymm10
+	vpsrlq	$32, %ymm3, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
 	vmovsldup	%ymm1, %ymm11
-	vpblendd	$170, %ymm11, %ymm7, %ymm3
-	vpsrlq	$32, %ymm7, %ymm5
-	vpblendd	$170, %ymm1, %ymm5, %ymm5
-	vmovsldup	%ymm6, %ymm11
-	vpblendd	$170, %ymm11, %ymm9, %ymm1
-	vpsrlq	$32, %ymm9, %ymm7
-	vpblendd	$170, %ymm6, %ymm7, %ymm6
-	vmovsldup	%ymm8, %ymm11
-	vpblendd	$170, %ymm11, %ymm4, %ymm7
+	vpblendd	$170, %ymm11, %ymm4, %ymm3
 	vpsrlq	$32, %ymm4, %ymm4
-	vpblendd	$170, %ymm8, %ymm4, %ymm8
+	vpblendd	$170, %ymm1, %ymm4, %ymm4
+	vmovsldup	%ymm6, %ymm11
+	vpblendd	$170, %ymm11, %ymm5, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm5
+	vmovsldup	%ymm7, %ymm6
+	vpblendd	$170, %ymm6, %ymm9, %ymm6
+	vpsrlq	$32, %ymm9, %ymm9
+	vpblendd	$170, %ymm7, %ymm9, %ymm7
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm10, %ymm9
-	vpsrld	$16, %ymm10, %ymm10
-	vpblendw	$170, %ymm1, %ymm10, %ymm0
-	vpslld	$16, %ymm6, %ymm11
+	vpblendw	$170, %ymm11, %ymm10, %ymm0
+	vpsrld	$16, %ymm10, %ymm8
+	vpblendw	$170, %ymm1, %ymm8, %ymm9
+	vpslld	$16, %ymm5, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
-	vpsrld	$16, %ymm2, %ymm10
-	vpblendw	$170, %ymm6, %ymm10, %ymm13
-	vpslld	$16, %ymm7, %ymm2
+	vpsrld	$16, %ymm2, %ymm8
+	vpblendw	$170, %ymm5, %ymm8, %ymm8
+	vpslld	$16, %ymm6, %ymm2
 	vpblendw	$170, %ymm2, %ymm3, %ymm2
 	vpsrld	$16, %ymm3, %ymm3
-	vpblendw	$170, %ymm7, %ymm3, %ymm4
-	vpslld	$16, %ymm8, %ymm6
-	vpblendw	$170, %ymm6, %ymm5, %ymm3
-	vpsrld	$16, %ymm5, %ymm7
-	vpblendw	$170, %ymm8, %ymm7, %ymm15
-	vmovdqu	%ymm9, 256(%rcx)
-	vmovdqu	%ymm0, 288(%rcx)
+	vpblendw	$170, %ymm6, %ymm3, %ymm10
+	vpslld	$16, %ymm7, %ymm6
+	vpblendw	$170, %ymm6, %ymm4, %ymm3
+	vpsrld	$16, %ymm4, %ymm14
+	vpblendw	$170, %ymm7, %ymm14, %ymm15
+	vmovdqu	%ymm0, 256(%rcx)
+	vmovdqu	%ymm9, 288(%rcx)
 	vmovdqu	%ymm1, 320(%rcx)
-	vmovdqu	%ymm13, 352(%rcx)
+	vmovdqu	%ymm8, 352(%rcx)
 	vmovdqu	%ymm2, 384(%rcx)
-	vmovdqu	%ymm4, 416(%rcx)
+	vmovdqu	%ymm10, 416(%rcx)
 	vmovdqu	%ymm3, 448(%rcx)
 	vmovdqu	%ymm15, 480(%rcx)
 	ret

--- a/code/jasmin/1024/avx2/jkem.s
+++ b/code/jasmin/1024/avx2/jkem.s
@@ -3486,398 +3486,104 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_dec$2:
 	vpor	%ymm2, %ymm0, %ymm0
 	vptest	%ymm0, %ymm0
 	cmovne	%rdx, %rax
-	movq	(%rbx), %rcx
-	movq	%rcx, 3776(%rsp)
-	movq	8(%rbx), %rcx
-	movq	%rcx, 3784(%rsp)
-	movq	16(%rbx), %rcx
-	movq	%rcx, 3792(%rsp)
-	movq	24(%rbx), %rcx
-	movq	%rcx, 3800(%rsp)
-	movq	32(%rbx), %rcx
-	movq	%rcx, 3808(%rsp)
-	movq	40(%rbx), %rcx
-	movq	%rcx, 3816(%rsp)
-	movq	48(%rbx), %rcx
-	movq	%rcx, 3824(%rsp)
-	movq	56(%rbx), %rcx
-	movq	%rcx, 3832(%rsp)
-	movq	64(%rbx), %rcx
-	movq	%rcx, 3840(%rsp)
-	movq	72(%rbx), %rcx
-	movq	%rcx, 3848(%rsp)
-	movq	80(%rbx), %rcx
-	movq	%rcx, 3856(%rsp)
-	movq	88(%rbx), %rcx
-	movq	%rcx, 3864(%rsp)
-	movq	96(%rbx), %rcx
-	movq	%rcx, 3872(%rsp)
-	movq	104(%rbx), %rcx
-	movq	%rcx, 3880(%rsp)
-	movq	112(%rbx), %rcx
-	movq	%rcx, 3888(%rsp)
-	movq	120(%rbx), %rcx
-	movq	%rcx, 3896(%rsp)
-	movq	128(%rbx), %rcx
-	movq	%rcx, 3904(%rsp)
-	movq	136(%rbx), %rcx
-	movq	%rcx, 3912(%rsp)
-	movq	144(%rbx), %rcx
-	movq	%rcx, 3920(%rsp)
-	movq	152(%rbx), %rcx
-	movq	%rcx, 3928(%rsp)
-	movq	160(%rbx), %rcx
-	movq	%rcx, 3936(%rsp)
-	movq	168(%rbx), %rcx
-	movq	%rcx, 3944(%rsp)
-	movq	176(%rbx), %rcx
-	movq	%rcx, 3952(%rsp)
-	movq	184(%rbx), %rcx
-	movq	%rcx, 3960(%rsp)
-	movq	192(%rbx), %rcx
-	movq	%rcx, 3968(%rsp)
-	movq	200(%rbx), %rcx
-	movq	%rcx, 3976(%rsp)
-	movq	208(%rbx), %rcx
-	movq	%rcx, 3984(%rsp)
-	movq	216(%rbx), %rcx
-	movq	%rcx, 3992(%rsp)
-	movq	224(%rbx), %rcx
-	movq	%rcx, 4000(%rsp)
-	movq	232(%rbx), %rcx
-	movq	%rcx, 4008(%rsp)
-	movq	240(%rbx), %rcx
-	movq	%rcx, 4016(%rsp)
-	movq	248(%rbx), %rcx
-	movq	%rcx, 4024(%rsp)
-	movq	256(%rbx), %rcx
-	movq	%rcx, 4032(%rsp)
-	movq	264(%rbx), %rcx
-	movq	%rcx, 4040(%rsp)
-	movq	272(%rbx), %rcx
-	movq	%rcx, 4048(%rsp)
-	movq	280(%rbx), %rcx
-	movq	%rcx, 4056(%rsp)
-	movq	288(%rbx), %rcx
-	movq	%rcx, 4064(%rsp)
-	movq	296(%rbx), %rcx
-	movq	%rcx, 4072(%rsp)
-	movq	304(%rbx), %rcx
-	movq	%rcx, 4080(%rsp)
-	movq	312(%rbx), %rcx
-	movq	%rcx, 4088(%rsp)
-	movq	320(%rbx), %rcx
-	movq	%rcx, 4096(%rsp)
-	movq	328(%rbx), %rcx
-	movq	%rcx, 4104(%rsp)
-	movq	336(%rbx), %rcx
-	movq	%rcx, 4112(%rsp)
-	movq	344(%rbx), %rcx
-	movq	%rcx, 4120(%rsp)
-	movq	352(%rbx), %rcx
-	movq	%rcx, 4128(%rsp)
-	movq	360(%rbx), %rcx
-	movq	%rcx, 4136(%rsp)
-	movq	368(%rbx), %rcx
-	movq	%rcx, 4144(%rsp)
-	movq	376(%rbx), %rcx
-	movq	%rcx, 4152(%rsp)
-	movq	384(%rbx), %rcx
-	movq	%rcx, 4160(%rsp)
-	movq	392(%rbx), %rcx
-	movq	%rcx, 4168(%rsp)
-	movq	400(%rbx), %rcx
-	movq	%rcx, 4176(%rsp)
-	movq	408(%rbx), %rcx
-	movq	%rcx, 4184(%rsp)
-	movq	416(%rbx), %rcx
-	movq	%rcx, 4192(%rsp)
-	movq	424(%rbx), %rcx
-	movq	%rcx, 4200(%rsp)
-	movq	432(%rbx), %rcx
-	movq	%rcx, 4208(%rsp)
-	movq	440(%rbx), %rcx
-	movq	%rcx, 4216(%rsp)
-	movq	448(%rbx), %rcx
-	movq	%rcx, 4224(%rsp)
-	movq	456(%rbx), %rcx
-	movq	%rcx, 4232(%rsp)
-	movq	464(%rbx), %rcx
-	movq	%rcx, 4240(%rsp)
-	movq	472(%rbx), %rcx
-	movq	%rcx, 4248(%rsp)
-	movq	480(%rbx), %rcx
-	movq	%rcx, 4256(%rsp)
-	movq	488(%rbx), %rcx
-	movq	%rcx, 4264(%rsp)
-	movq	496(%rbx), %rcx
-	movq	%rcx, 4272(%rsp)
-	movq	504(%rbx), %rcx
-	movq	%rcx, 4280(%rsp)
-	movq	512(%rbx), %rcx
-	movq	%rcx, 4288(%rsp)
-	movq	520(%rbx), %rcx
-	movq	%rcx, 4296(%rsp)
-	movq	528(%rbx), %rcx
-	movq	%rcx, 4304(%rsp)
-	movq	536(%rbx), %rcx
-	movq	%rcx, 4312(%rsp)
-	movq	544(%rbx), %rcx
-	movq	%rcx, 4320(%rsp)
-	movq	552(%rbx), %rcx
-	movq	%rcx, 4328(%rsp)
-	movq	560(%rbx), %rcx
-	movq	%rcx, 4336(%rsp)
-	movq	568(%rbx), %rcx
-	movq	%rcx, 4344(%rsp)
-	movq	576(%rbx), %rcx
-	movq	%rcx, 4352(%rsp)
-	movq	584(%rbx), %rcx
-	movq	%rcx, 4360(%rsp)
-	movq	592(%rbx), %rcx
-	movq	%rcx, 4368(%rsp)
-	movq	600(%rbx), %rcx
-	movq	%rcx, 4376(%rsp)
-	movq	608(%rbx), %rcx
-	movq	%rcx, 4384(%rsp)
-	movq	616(%rbx), %rcx
-	movq	%rcx, 4392(%rsp)
-	movq	624(%rbx), %rcx
-	movq	%rcx, 4400(%rsp)
-	movq	632(%rbx), %rcx
-	movq	%rcx, 4408(%rsp)
-	movq	640(%rbx), %rcx
-	movq	%rcx, 4416(%rsp)
-	movq	648(%rbx), %rcx
-	movq	%rcx, 4424(%rsp)
-	movq	656(%rbx), %rcx
-	movq	%rcx, 4432(%rsp)
-	movq	664(%rbx), %rcx
-	movq	%rcx, 4440(%rsp)
-	movq	672(%rbx), %rcx
-	movq	%rcx, 4448(%rsp)
-	movq	680(%rbx), %rcx
-	movq	%rcx, 4456(%rsp)
-	movq	688(%rbx), %rcx
-	movq	%rcx, 4464(%rsp)
-	movq	696(%rbx), %rcx
-	movq	%rcx, 4472(%rsp)
-	movq	704(%rbx), %rcx
-	movq	%rcx, 4480(%rsp)
-	movq	712(%rbx), %rcx
-	movq	%rcx, 4488(%rsp)
-	movq	720(%rbx), %rcx
-	movq	%rcx, 4496(%rsp)
-	movq	728(%rbx), %rcx
-	movq	%rcx, 4504(%rsp)
-	movq	736(%rbx), %rcx
-	movq	%rcx, 4512(%rsp)
-	movq	744(%rbx), %rcx
-	movq	%rcx, 4520(%rsp)
-	movq	752(%rbx), %rcx
-	movq	%rcx, 4528(%rsp)
-	movq	760(%rbx), %rcx
-	movq	%rcx, 4536(%rsp)
-	movq	768(%rbx), %rcx
-	movq	%rcx, 4544(%rsp)
-	movq	776(%rbx), %rcx
-	movq	%rcx, 4552(%rsp)
-	movq	784(%rbx), %rcx
-	movq	%rcx, 4560(%rsp)
-	movq	792(%rbx), %rcx
-	movq	%rcx, 4568(%rsp)
-	movq	800(%rbx), %rcx
-	movq	%rcx, 4576(%rsp)
-	movq	808(%rbx), %rcx
-	movq	%rcx, 4584(%rsp)
-	movq	816(%rbx), %rcx
-	movq	%rcx, 4592(%rsp)
-	movq	824(%rbx), %rcx
-	movq	%rcx, 4600(%rsp)
-	movq	832(%rbx), %rcx
-	movq	%rcx, 4608(%rsp)
-	movq	840(%rbx), %rcx
-	movq	%rcx, 4616(%rsp)
-	movq	848(%rbx), %rcx
-	movq	%rcx, 4624(%rsp)
-	movq	856(%rbx), %rcx
-	movq	%rcx, 4632(%rsp)
-	movq	864(%rbx), %rcx
-	movq	%rcx, 4640(%rsp)
-	movq	872(%rbx), %rcx
-	movq	%rcx, 4648(%rsp)
-	movq	880(%rbx), %rcx
-	movq	%rcx, 4656(%rsp)
-	movq	888(%rbx), %rcx
-	movq	%rcx, 4664(%rsp)
-	movq	896(%rbx), %rcx
-	movq	%rcx, 4672(%rsp)
-	movq	904(%rbx), %rcx
-	movq	%rcx, 4680(%rsp)
-	movq	912(%rbx), %rcx
-	movq	%rcx, 4688(%rsp)
-	movq	920(%rbx), %rcx
-	movq	%rcx, 4696(%rsp)
-	movq	928(%rbx), %rcx
-	movq	%rcx, 4704(%rsp)
-	movq	936(%rbx), %rcx
-	movq	%rcx, 4712(%rsp)
-	movq	944(%rbx), %rcx
-	movq	%rcx, 4720(%rsp)
-	movq	952(%rbx), %rcx
-	movq	%rcx, 4728(%rsp)
-	movq	960(%rbx), %rcx
-	movq	%rcx, 4736(%rsp)
-	movq	968(%rbx), %rcx
-	movq	%rcx, 4744(%rsp)
-	movq	976(%rbx), %rcx
-	movq	%rcx, 4752(%rsp)
-	movq	984(%rbx), %rcx
-	movq	%rcx, 4760(%rsp)
-	movq	992(%rbx), %rcx
-	movq	%rcx, 4768(%rsp)
-	movq	1000(%rbx), %rcx
-	movq	%rcx, 4776(%rsp)
-	movq	1008(%rbx), %rcx
-	movq	%rcx, 4784(%rsp)
-	movq	1016(%rbx), %rcx
-	movq	%rcx, 4792(%rsp)
-	movq	1024(%rbx), %rcx
-	movq	%rcx, 4800(%rsp)
-	movq	1032(%rbx), %rcx
-	movq	%rcx, 4808(%rsp)
-	movq	1040(%rbx), %rcx
-	movq	%rcx, 4816(%rsp)
-	movq	1048(%rbx), %rcx
-	movq	%rcx, 4824(%rsp)
-	movq	1056(%rbx), %rcx
-	movq	%rcx, 4832(%rsp)
-	movq	1064(%rbx), %rcx
-	movq	%rcx, 4840(%rsp)
-	movq	1072(%rbx), %rcx
-	movq	%rcx, 4848(%rsp)
-	movq	1080(%rbx), %rcx
-	movq	%rcx, 4856(%rsp)
-	movq	1088(%rbx), %rcx
-	movq	%rcx, 4864(%rsp)
-	movq	1096(%rbx), %rcx
-	movq	%rcx, 4872(%rsp)
-	movq	1104(%rbx), %rcx
-	movq	%rcx, 4880(%rsp)
-	movq	1112(%rbx), %rcx
-	movq	%rcx, 4888(%rsp)
-	movq	1120(%rbx), %rcx
-	movq	%rcx, 4896(%rsp)
-	movq	1128(%rbx), %rcx
-	movq	%rcx, 4904(%rsp)
-	movq	1136(%rbx), %rcx
-	movq	%rcx, 4912(%rsp)
-	movq	1144(%rbx), %rcx
-	movq	%rcx, 4920(%rsp)
-	movq	1152(%rbx), %rcx
-	movq	%rcx, 4928(%rsp)
-	movq	1160(%rbx), %rcx
-	movq	%rcx, 4936(%rsp)
-	movq	1168(%rbx), %rcx
-	movq	%rcx, 4944(%rsp)
-	movq	1176(%rbx), %rcx
-	movq	%rcx, 4952(%rsp)
-	movq	1184(%rbx), %rcx
-	movq	%rcx, 4960(%rsp)
-	movq	1192(%rbx), %rcx
-	movq	%rcx, 4968(%rsp)
-	movq	1200(%rbx), %rcx
-	movq	%rcx, 4976(%rsp)
-	movq	1208(%rbx), %rcx
-	movq	%rcx, 4984(%rsp)
-	movq	1216(%rbx), %rcx
-	movq	%rcx, 4992(%rsp)
-	movq	1224(%rbx), %rcx
-	movq	%rcx, 5000(%rsp)
-	movq	1232(%rbx), %rcx
-	movq	%rcx, 5008(%rsp)
-	movq	1240(%rbx), %rcx
-	movq	%rcx, 5016(%rsp)
-	movq	1248(%rbx), %rcx
-	movq	%rcx, 5024(%rsp)
-	movq	1256(%rbx), %rcx
-	movq	%rcx, 5032(%rsp)
-	movq	1264(%rbx), %rcx
-	movq	%rcx, 5040(%rsp)
-	movq	1272(%rbx), %rcx
-	movq	%rcx, 5048(%rsp)
-	movq	1280(%rbx), %rcx
-	movq	%rcx, 5056(%rsp)
-	movq	1288(%rbx), %rcx
-	movq	%rcx, 5064(%rsp)
-	movq	1296(%rbx), %rcx
-	movq	%rcx, 5072(%rsp)
-	movq	1304(%rbx), %rcx
-	movq	%rcx, 5080(%rsp)
-	movq	1312(%rbx), %rcx
-	movq	%rcx, 5088(%rsp)
-	movq	1320(%rbx), %rcx
-	movq	%rcx, 5096(%rsp)
-	movq	1328(%rbx), %rcx
-	movq	%rcx, 5104(%rsp)
-	movq	1336(%rbx), %rcx
-	movq	%rcx, 5112(%rsp)
-	movq	1344(%rbx), %rcx
-	movq	%rcx, 5120(%rsp)
-	movq	1352(%rbx), %rcx
-	movq	%rcx, 5128(%rsp)
-	movq	1360(%rbx), %rcx
-	movq	%rcx, 5136(%rsp)
-	movq	1368(%rbx), %rcx
-	movq	%rcx, 5144(%rsp)
-	movq	1376(%rbx), %rcx
-	movq	%rcx, 5152(%rsp)
-	movq	1384(%rbx), %rcx
-	movq	%rcx, 5160(%rsp)
-	movq	1392(%rbx), %rcx
-	movq	%rcx, 5168(%rsp)
-	movq	1400(%rbx), %rcx
-	movq	%rcx, 5176(%rsp)
-	movq	1408(%rbx), %rcx
-	movq	%rcx, 5184(%rsp)
-	movq	1416(%rbx), %rcx
-	movq	%rcx, 5192(%rsp)
-	movq	1424(%rbx), %rcx
-	movq	%rcx, 5200(%rsp)
-	movq	1432(%rbx), %rcx
-	movq	%rcx, 5208(%rsp)
-	movq	1440(%rbx), %rcx
-	movq	%rcx, 5216(%rsp)
-	movq	1448(%rbx), %rcx
-	movq	%rcx, 5224(%rsp)
-	movq	1456(%rbx), %rcx
-	movq	%rcx, 5232(%rsp)
-	movq	1464(%rbx), %rcx
-	movq	%rcx, 5240(%rsp)
-	movq	1472(%rbx), %rcx
-	movq	%rcx, 5248(%rsp)
-	movq	1480(%rbx), %rcx
-	movq	%rcx, 5256(%rsp)
-	movq	1488(%rbx), %rcx
-	movq	%rcx, 5264(%rsp)
-	movq	1496(%rbx), %rcx
-	movq	%rcx, 5272(%rsp)
-	movq	1504(%rbx), %rcx
-	movq	%rcx, 5280(%rsp)
-	movq	1512(%rbx), %rcx
-	movq	%rcx, 5288(%rsp)
-	movq	1520(%rbx), %rcx
-	movq	%rcx, 5296(%rsp)
-	movq	1528(%rbx), %rcx
-	movq	%rcx, 5304(%rsp)
-	movq	1536(%rbx), %rcx
-	movq	%rcx, 5312(%rsp)
-	movq	1544(%rbx), %rcx
-	movq	%rcx, 5320(%rsp)
-	movq	1552(%rbx), %rcx
-	movq	%rcx, 5328(%rsp)
-	movq	1560(%rbx), %rcx
-	movq	%rcx, 5336(%rsp)
+	vmovdqu	(%rbx), %ymm0
+	vmovdqu	%ymm0, 3776(%rsp)
+	vmovdqu	32(%rbx), %ymm0
+	vmovdqu	%ymm0, 3808(%rsp)
+	vmovdqu	64(%rbx), %ymm0
+	vmovdqu	%ymm0, 3840(%rsp)
+	vmovdqu	96(%rbx), %ymm0
+	vmovdqu	%ymm0, 3872(%rsp)
+	vmovdqu	128(%rbx), %ymm0
+	vmovdqu	%ymm0, 3904(%rsp)
+	vmovdqu	160(%rbx), %ymm0
+	vmovdqu	%ymm0, 3936(%rsp)
+	vmovdqu	192(%rbx), %ymm0
+	vmovdqu	%ymm0, 3968(%rsp)
+	vmovdqu	224(%rbx), %ymm0
+	vmovdqu	%ymm0, 4000(%rsp)
+	vmovdqu	256(%rbx), %ymm0
+	vmovdqu	%ymm0, 4032(%rsp)
+	vmovdqu	288(%rbx), %ymm0
+	vmovdqu	%ymm0, 4064(%rsp)
+	vmovdqu	320(%rbx), %ymm0
+	vmovdqu	%ymm0, 4096(%rsp)
+	vmovdqu	352(%rbx), %ymm0
+	vmovdqu	%ymm0, 4128(%rsp)
+	vmovdqu	384(%rbx), %ymm0
+	vmovdqu	%ymm0, 4160(%rsp)
+	vmovdqu	416(%rbx), %ymm0
+	vmovdqu	%ymm0, 4192(%rsp)
+	vmovdqu	448(%rbx), %ymm0
+	vmovdqu	%ymm0, 4224(%rsp)
+	vmovdqu	480(%rbx), %ymm0
+	vmovdqu	%ymm0, 4256(%rsp)
+	vmovdqu	512(%rbx), %ymm0
+	vmovdqu	%ymm0, 4288(%rsp)
+	vmovdqu	544(%rbx), %ymm0
+	vmovdqu	%ymm0, 4320(%rsp)
+	vmovdqu	576(%rbx), %ymm0
+	vmovdqu	%ymm0, 4352(%rsp)
+	vmovdqu	608(%rbx), %ymm0
+	vmovdqu	%ymm0, 4384(%rsp)
+	vmovdqu	640(%rbx), %ymm0
+	vmovdqu	%ymm0, 4416(%rsp)
+	vmovdqu	672(%rbx), %ymm0
+	vmovdqu	%ymm0, 4448(%rsp)
+	vmovdqu	704(%rbx), %ymm0
+	vmovdqu	%ymm0, 4480(%rsp)
+	vmovdqu	736(%rbx), %ymm0
+	vmovdqu	%ymm0, 4512(%rsp)
+	vmovdqu	768(%rbx), %ymm0
+	vmovdqu	%ymm0, 4544(%rsp)
+	vmovdqu	800(%rbx), %ymm0
+	vmovdqu	%ymm0, 4576(%rsp)
+	vmovdqu	832(%rbx), %ymm0
+	vmovdqu	%ymm0, 4608(%rsp)
+	vmovdqu	864(%rbx), %ymm0
+	vmovdqu	%ymm0, 4640(%rsp)
+	vmovdqu	896(%rbx), %ymm0
+	vmovdqu	%ymm0, 4672(%rsp)
+	vmovdqu	928(%rbx), %ymm0
+	vmovdqu	%ymm0, 4704(%rsp)
+	vmovdqu	960(%rbx), %ymm0
+	vmovdqu	%ymm0, 4736(%rsp)
+	vmovdqu	992(%rbx), %ymm0
+	vmovdqu	%ymm0, 4768(%rsp)
+	vmovdqu	1024(%rbx), %ymm0
+	vmovdqu	%ymm0, 4800(%rsp)
+	vmovdqu	1056(%rbx), %ymm0
+	vmovdqu	%ymm0, 4832(%rsp)
+	vmovdqu	1088(%rbx), %ymm0
+	vmovdqu	%ymm0, 4864(%rsp)
+	vmovdqu	1120(%rbx), %ymm0
+	vmovdqu	%ymm0, 4896(%rsp)
+	vmovdqu	1152(%rbx), %ymm0
+	vmovdqu	%ymm0, 4928(%rsp)
+	vmovdqu	1184(%rbx), %ymm0
+	vmovdqu	%ymm0, 4960(%rsp)
+	vmovdqu	1216(%rbx), %ymm0
+	vmovdqu	%ymm0, 4992(%rsp)
+	vmovdqu	1248(%rbx), %ymm0
+	vmovdqu	%ymm0, 5024(%rsp)
+	vmovdqu	1280(%rbx), %ymm0
+	vmovdqu	%ymm0, 5056(%rsp)
+	vmovdqu	1312(%rbx), %ymm0
+	vmovdqu	%ymm0, 5088(%rsp)
+	vmovdqu	1344(%rbx), %ymm0
+	vmovdqu	%ymm0, 5120(%rsp)
+	vmovdqu	1376(%rbx), %ymm0
+	vmovdqu	%ymm0, 5152(%rsp)
+	vmovdqu	1408(%rbx), %ymm0
+	vmovdqu	%ymm0, 5184(%rsp)
+	vmovdqu	1440(%rbx), %ymm0
+	vmovdqu	%ymm0, 5216(%rsp)
+	vmovdqu	1472(%rbx), %ymm0
+	vmovdqu	%ymm0, 5248(%rsp)
+	vmovdqu	1504(%rbx), %ymm0
+	vmovdqu	%ymm0, 5280(%rsp)
+	vmovdqu	1536(%rbx), %ymm0
+	vmovdqu	%ymm0, 5312(%rsp)
 	movq	%mm1, %rsi
 	leaq	3744(%rsp), %rbp
 	call	L_shake256_A32__A1600$1
@@ -11355,12 +11061,12 @@ L_gen_matrix_buf_rejection$14:
 	cmovnbe	%r12, %r11
 	vmovdqu	%xmm4, (%r9,%rbp,2)
 L_gen_matrix_buf_rejection$15:
-	vextracti128	$1, %ymm3, %xmm3
+	vextracti128	$1, %ymm3, %xmm4
 	cmpq	$248, %r13
 	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	movq	%xmm3, %r12
+	movq	%xmm4, %r12
 	cmpq	$252, %r13
 	jbe 	L_gen_matrix_buf_rejection$12
 	movq	$-1, %rbp
@@ -11370,7 +11076,7 @@ L_gen_matrix_buf_rejection$12:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
 	movq	%r12, (%r9,%r13,2)
-	vpextrq	$1, %xmm3, %r12
+	vpextrq	$1, %xmm4, %r12
 	addq	$4, %r13
 L_gen_matrix_buf_rejection$13:
 	cmpq	$254, %r13
@@ -11399,7 +11105,7 @@ L_gen_matrix_buf_rejection$9:
 L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
-	vmovdqu	%xmm3, (%r9,%r13,2)
+	vmovdqu	%xmm4, (%r9,%r13,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r14, %rbp
 	movq	8(%rsp), %r13
@@ -11742,27 +11448,27 @@ L_i_poly_tobytes$2:
 	vmovsldup	%ymm3, %ymm6
 	vpblendd	$170, %ymm6, %ymm9, %ymm6
 	vpsrlq	$32, %ymm9, %ymm7
-	vpblendd	$170, %ymm3, %ymm7, %ymm3
-	vmovsldup	%ymm1, %ymm11
-	vpblendd	$170, %ymm11, %ymm4, %ymm7
+	vpblendd	$170, %ymm3, %ymm7, %ymm11
+	vmovsldup	%ymm1, %ymm15
+	vpblendd	$170, %ymm15, %ymm4, %ymm3
 	vpsrlq	$32, %ymm4, %ymm4
 	vpblendd	$170, %ymm1, %ymm4, %ymm1
 	vpunpcklqdq	%ymm6, %ymm2, %ymm4
 	vpunpckhqdq	%ymm6, %ymm2, %ymm0
-	vpunpcklqdq	%ymm5, %ymm7, %ymm6
-	vpunpckhqdq	%ymm5, %ymm7, %ymm2
-	vpunpcklqdq	%ymm1, %ymm3, %ymm8
-	vpunpckhqdq	%ymm1, %ymm3, %ymm1
-	vperm2i128	$32, %ymm6, %ymm4, %ymm11
-	vperm2i128	$49, %ymm6, %ymm4, %ymm6
-	vperm2i128	$32, %ymm0, %ymm8, %ymm4
-	vperm2i128	$49, %ymm0, %ymm8, %ymm0
-	vperm2i128	$32, %ymm1, %ymm2, %ymm3
-	vperm2i128	$49, %ymm1, %ymm2, %ymm1
+	vpunpcklqdq	%ymm5, %ymm3, %ymm2
+	vpunpckhqdq	%ymm5, %ymm3, %ymm6
+	vpunpcklqdq	%ymm1, %ymm11, %ymm3
+	vpunpckhqdq	%ymm1, %ymm11, %ymm1
+	vperm2i128	$32, %ymm2, %ymm4, %ymm11
+	vperm2i128	$49, %ymm2, %ymm4, %ymm10
+	vperm2i128	$32, %ymm0, %ymm3, %ymm2
+	vperm2i128	$49, %ymm0, %ymm3, %ymm0
+	vperm2i128	$32, %ymm1, %ymm6, %ymm3
+	vperm2i128	$49, %ymm1, %ymm6, %ymm1
 	vmovdqu	%ymm11, (%rsi)
-	vmovdqu	%ymm4, 32(%rsi)
+	vmovdqu	%ymm2, 32(%rsi)
 	vmovdqu	%ymm3, 64(%rsi)
-	vmovdqu	%ymm6, 96(%rsi)
+	vmovdqu	%ymm10, 96(%rsi)
 	vmovdqu	%ymm0, 128(%rsi)
 	vmovdqu	%ymm1, 160(%rsi)
 	vmovdqu	256(%rcx), %ymm6
@@ -11816,21 +11522,21 @@ L_i_poly_tobytes$2:
 	vpunpcklqdq	%ymm6, %ymm2, %ymm4
 	vpunpckhqdq	%ymm6, %ymm2, %ymm2
 	vpunpcklqdq	%ymm5, %ymm7, %ymm6
-	vpunpckhqdq	%ymm5, %ymm7, %ymm5
-	vpunpcklqdq	%ymm1, %ymm3, %ymm7
+	vpunpckhqdq	%ymm5, %ymm7, %ymm0
+	vpunpcklqdq	%ymm1, %ymm3, %ymm5
 	vpunpckhqdq	%ymm1, %ymm3, %ymm1
 	vperm2i128	$32, %ymm6, %ymm4, %ymm11
 	vperm2i128	$49, %ymm6, %ymm4, %ymm6
-	vperm2i128	$32, %ymm2, %ymm7, %ymm4
-	vperm2i128	$49, %ymm2, %ymm7, %ymm0
-	vperm2i128	$32, %ymm1, %ymm5, %ymm3
-	vperm2i128	$49, %ymm1, %ymm5, %ymm9
+	vperm2i128	$32, %ymm2, %ymm5, %ymm4
+	vperm2i128	$49, %ymm2, %ymm5, %ymm2
+	vperm2i128	$32, %ymm1, %ymm0, %ymm3
+	vperm2i128	$49, %ymm1, %ymm0, %ymm1
 	vmovdqu	%ymm11, 192(%rsi)
 	vmovdqu	%ymm4, 224(%rsi)
 	vmovdqu	%ymm3, 256(%rsi)
 	vmovdqu	%ymm6, 288(%rsi)
-	vmovdqu	%ymm0, 320(%rsi)
-	vmovdqu	%ymm9, 352(%rsi)
+	vmovdqu	%ymm2, 320(%rsi)
+	vmovdqu	%ymm1, 352(%rsi)
 	ret
 L_poly_sub$1:
 	vmovdqu	(%rsi), %ymm2
@@ -11936,7 +11642,7 @@ L_poly_ntt$1:
 	vpsubw	%ymm9, %ymm14, %ymm9
 	vpaddw	%ymm12, %ymm10, %ymm12
 	vpsubw	%ymm10, %ymm1, %ymm1
-	vpaddw	%ymm7, %ymm11, %ymm15
+	vpaddw	%ymm7, %ymm11, %ymm7
 	vpsubw	%ymm11, %ymm3, %ymm14
 	vmovdqu	%ymm6, (%rcx)
 	vmovdqu	%ymm9, 32(%rcx)
@@ -11945,7 +11651,7 @@ L_poly_ntt$1:
 	vmovdqu	%ymm5, 256(%rcx)
 	vmovdqu	%ymm8, 288(%rcx)
 	vmovdqu	%ymm12, 320(%rcx)
-	vmovdqu	%ymm15, 352(%rcx)
+	vmovdqu	%ymm7, 352(%rcx)
 	vmovdqu	128(%rcx), %ymm8
 	vmovdqu	160(%rcx), %ymm6
 	vmovdqu	192(%rcx), %ymm1
@@ -11975,26 +11681,28 @@ L_poly_ntt$1:
 	vpsubw	%ymm5, %ymm1, %ymm12
 	vpaddw	%ymm1, %ymm5, %ymm1
 	vpaddw	%ymm9, %ymm2, %ymm5
-	vpsubw	%ymm2, %ymm8, %ymm8
-	vpaddw	%ymm13, %ymm4, %ymm9
+	vpsubw	%ymm2, %ymm8, %ymm9
+	vpaddw	%ymm13, %ymm4, %ymm8
 	vpsubw	%ymm4, %ymm6, %ymm6
-	vpaddw	%ymm12, %ymm10, %ymm4
-	vpsubw	%ymm10, %ymm1, %ymm12
-	vpaddw	%ymm7, %ymm11, %ymm15
+	vpaddw	%ymm12, %ymm10, %ymm12
+	vpsubw	%ymm10, %ymm1, %ymm1
+	vpaddw	%ymm7, %ymm11, %ymm4
 	vpsubw	%ymm11, %ymm3, %ymm13
 	vmovdqu	%ymm5, 384(%rcx)
-	vmovdqu	%ymm9, 416(%rcx)
-	vmovdqu	%ymm4, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm8, 416(%rcx)
+	vmovdqu	%ymm12, 448(%rcx)
+	vmovdqu	%ymm4, 480(%rcx)
 	vpbroadcastd	glob_data + 2024(%rip), %ymm2
 	vpbroadcastd	glob_data + 2028(%rip), %ymm4
+	vmovdqu	%ymm9, %ymm11
 	vmovdqu	%ymm6, %ymm10
+	vmovdqu	%ymm1, %ymm12
 	vmovdqu	(%rcx), %ymm9
 	vmovdqu	32(%rcx), %ymm6
 	vmovdqu	64(%rcx), %ymm7
 	vmovdqu	96(%rcx), %ymm5
-	vpmullw	%ymm8, %ymm2, %ymm15
-	vpmulhw	%ymm8, %ymm4, %ymm3
+	vpmullw	%ymm11, %ymm2, %ymm15
+	vpmulhw	%ymm11, %ymm4, %ymm3
 	vpmullw	%ymm10, %ymm2, %ymm11
 	vpmulhw	%ymm10, %ymm4, %ymm10
 	vpmullw	%ymm12, %ymm2, %ymm1
@@ -12107,8 +11815,8 @@ L_poly_ntt$1:
 	vpblendd	$170, %ymm2, %ymm4, %ymm2
 	vpsrlq	$32, %ymm4, %ymm4
 	vpblendd	$170, %ymm8, %ymm4, %ymm8
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm11, %ymm15
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm11, %ymm15
 	vpsrlq	$32, %ymm11, %ymm4
 	vpblendd	$170, %ymm6, %ymm4, %ymm14
 	vmovsldup	%ymm1, %ymm6
@@ -12237,7 +11945,7 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm6, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
-	vpsubw	%ymm7, %ymm6, %ymm12
+	vpsubw	%ymm7, %ymm6, %ymm10
 	vpmulhw	%ymm5, %ymm11, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
@@ -12253,18 +11961,18 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm3, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm3, %ymm15
+	vpsubw	%ymm5, %ymm3, %ymm7
 	vmovdqu	%ymm2, (%rcx)
 	vmovdqu	%ymm4, 32(%rcx)
 	vmovdqu	%ymm6, 64(%rcx)
 	vmovdqu	%ymm8, 96(%rcx)
 	vmovdqu	%ymm1, 128(%rcx)
-	vmovdqu	%ymm12, 160(%rcx)
+	vmovdqu	%ymm10, 160(%rcx)
 	vmovdqu	%ymm13, 192(%rcx)
-	vmovdqu	%ymm15, 224(%rcx)
+	vmovdqu	%ymm7, 224(%rcx)
 	vpbroadcastd	glob_data + 2416(%rip), %ymm2
 	vpbroadcastd	glob_data + 2420(%rip), %ymm6
-	vmovdqu	384(%rcx), %ymm8
+	vmovdqu	384(%rcx), %ymm15
 	vmovdqu	416(%rcx), %ymm13
 	vmovdqu	448(%rcx), %ymm5
 	vmovdqu	480(%rcx), %ymm7
@@ -12272,8 +11980,8 @@ L_poly_ntt$1:
 	vmovdqu	288(%rcx), %ymm3
 	vmovdqu	320(%rcx), %ymm12
 	vmovdqu	352(%rcx), %ymm4
-	vpmullw	%ymm8, %ymm2, %ymm11
-	vpmulhw	%ymm8, %ymm6, %ymm10
+	vpmullw	%ymm15, %ymm2, %ymm11
+	vpmulhw	%ymm15, %ymm6, %ymm10
 	vpmullw	%ymm13, %ymm2, %ymm8
 	vpmulhw	%ymm13, %ymm6, %ymm15
 	vpmullw	%ymm5, %ymm2, %ymm1
@@ -12378,30 +12086,30 @@ L_poly_ntt$1:
 	vpsubw	%ymm2, %ymm5, %ymm2
 	vmovdqu	glob_data + 2552(%rip), %ymm3
 	vmovdqu	glob_data + 2584(%rip), %ymm5
-	vmovsldup	%ymm7, %ymm14
-	vpblendd	$170, %ymm14, %ymm10, %ymm9
+	vmovsldup	%ymm7, %ymm15
+	vpblendd	$170, %ymm15, %ymm10, %ymm9
 	vpsrlq	$32, %ymm10, %ymm10
 	vpblendd	$170, %ymm7, %ymm10, %ymm7
-	vmovsldup	%ymm8, %ymm14
-	vpblendd	$170, %ymm14, %ymm4, %ymm1
+	vmovsldup	%ymm8, %ymm15
+	vpblendd	$170, %ymm15, %ymm4, %ymm1
 	vpsrlq	$32, %ymm4, %ymm4
 	vpblendd	$170, %ymm8, %ymm4, %ymm8
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm11, %ymm4
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm11, %ymm4
 	vpsrlq	$32, %ymm11, %ymm10
 	vpblendd	$170, %ymm6, %ymm10, %ymm10
 	vmovsldup	%ymm13, %ymm6
-	vpblendd	$170, %ymm6, %ymm2, %ymm12
+	vpblendd	$170, %ymm6, %ymm2, %ymm15
 	vpsrlq	$32, %ymm2, %ymm2
-	vpblendd	$170, %ymm13, %ymm2, %ymm15
+	vpblendd	$170, %ymm13, %ymm2, %ymm12
 	vpmullw	%ymm4, %ymm3, %ymm6
 	vpmulhw	%ymm4, %ymm5, %ymm14
 	vpmullw	%ymm10, %ymm3, %ymm4
 	vpmulhw	%ymm10, %ymm5, %ymm10
-	vpmullw	%ymm12, %ymm3, %ymm11
-	vpmulhw	%ymm12, %ymm5, %ymm2
-	vpmullw	%ymm15, %ymm3, %ymm13
-	vpmulhw	%ymm15, %ymm5, %ymm12
+	vpmullw	%ymm15, %ymm3, %ymm11
+	vpmulhw	%ymm15, %ymm5, %ymm2
+	vpmullw	%ymm12, %ymm3, %ymm13
+	vpmulhw	%ymm12, %ymm5, %ymm12
 	vpmulhw	%ymm0, %ymm6, %ymm6
 	vpmulhw	%ymm0, %ymm4, %ymm4
 	vpmulhw	%ymm0, %ymm11, %ymm3
@@ -12516,7 +12224,7 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm6, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
-	vpsubw	%ymm7, %ymm6, %ymm12
+	vpsubw	%ymm7, %ymm6, %ymm10
 	vpmulhw	%ymm5, %ymm11, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
@@ -12532,15 +12240,15 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm3, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm3, %ymm15
+	vpsubw	%ymm5, %ymm3, %ymm7
 	vmovdqu	%ymm2, 256(%rcx)
 	vmovdqu	%ymm4, 288(%rcx)
 	vmovdqu	%ymm6, 320(%rcx)
 	vmovdqu	%ymm8, 352(%rcx)
 	vmovdqu	%ymm1, 384(%rcx)
-	vmovdqu	%ymm12, 416(%rcx)
+	vmovdqu	%ymm10, 416(%rcx)
 	vmovdqu	%ymm13, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm7, 480(%rcx)
 	ret
 L_poly_invntt$1:
 	vmovdqu	glob_data + 1184(%rip), %ymm0
@@ -12673,8 +12381,8 @@ L_poly_invntt$1:
 	vpblendd	$170, %ymm11, %ymm7, %ymm9
 	vpsrlq	$32, %ymm7, %ymm7
 	vpblendd	$170, %ymm10, %ymm7, %ymm11
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm12, %ymm10
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm12, %ymm10
 	vpsrlq	$32, %ymm12, %ymm7
 	vpblendd	$170, %ymm6, %ymm7, %ymm14
 	vmovsldup	%ymm3, %ymm6
@@ -12786,19 +12494,19 @@ L_poly_invntt$1:
 	vpsubw	%ymm11, %ymm6, %ymm6
 	vpsubw	%ymm13, %ymm8, %ymm8
 	vpsubw	%ymm4, %ymm12, %ymm4
-	vpsubw	%ymm5, %ymm14, %ymm15
+	vpsubw	%ymm5, %ymm14, %ymm7
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm1
-	vmovdqu	%ymm1, (%rcx)
+	vpsubw	%ymm5, %ymm9, %ymm9
+	vmovdqu	%ymm9, (%rcx)
 	vmovdqu	%ymm10, 32(%rcx)
 	vmovdqu	%ymm2, 64(%rcx)
 	vmovdqu	%ymm3, 96(%rcx)
 	vmovdqu	%ymm6, 128(%rcx)
 	vmovdqu	%ymm8, 160(%rcx)
 	vmovdqu	%ymm4, 192(%rcx)
-	vmovdqu	%ymm15, 224(%rcx)
+	vmovdqu	%ymm7, 224(%rcx)
 	vmovdqu	glob_data + 1608(%rip), %ymm10
 	vmovdqu	glob_data + 1672(%rip), %ymm1
 	vmovdqu	glob_data + 1640(%rip), %ymm2
@@ -12827,11 +12535,11 @@ L_poly_invntt$1:
 	vpmulhw	%ymm7, %ymm2, %ymm7
 	vpmulhw	%ymm8, %ymm5, %ymm2
 	vpmulhw	%ymm10, %ymm5, %ymm10
-	vpmulhw	%ymm9, %ymm0, %ymm8
+	vpmulhw	%ymm9, %ymm0, %ymm9
 	vpmulhw	%ymm13, %ymm0, %ymm13
 	vpmulhw	%ymm12, %ymm0, %ymm5
 	vpmulhw	%ymm1, %ymm0, %ymm1
-	vpsubw	%ymm8, %ymm15, %ymm12
+	vpsubw	%ymm9, %ymm15, %ymm12
 	vpsubw	%ymm13, %ymm7, %ymm8
 	vpsubw	%ymm5, %ymm2, %ymm9
 	vpsubw	%ymm1, %ymm10, %ymm7
@@ -13041,36 +12749,38 @@ L_poly_invntt$1:
 	vpsubw	%ymm11, %ymm6, %ymm6
 	vpsubw	%ymm13, %ymm8, %ymm8
 	vpsubw	%ymm4, %ymm12, %ymm4
-	vpsubw	%ymm5, %ymm14, %ymm15
+	vpsubw	%ymm5, %ymm14, %ymm7
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm7
+	vpsubw	%ymm5, %ymm9, %ymm9
 	vmovdqu	%ymm6, 384(%rcx)
 	vmovdqu	%ymm8, 416(%rcx)
 	vmovdqu	%ymm4, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm7, 480(%rcx)
 	vpbroadcastd	glob_data + 2000(%rip), %ymm1
 	vpbroadcastd	glob_data + 2004(%rip), %ymm5
-	vmovdqu	%ymm3, %ymm15
-	vmovdqu	%ymm2, %ymm4
-	vmovdqu	(%rcx), %ymm13
-	vmovdqu	32(%rcx), %ymm3
-	vmovdqu	64(%rcx), %ymm6
+	vmovdqu	%ymm3, %ymm4
+	vmovdqu	%ymm2, %ymm6
+	vmovdqu	%ymm10, %ymm3
+	vmovdqu	%ymm9, %ymm2
+	vmovdqu	(%rcx), %ymm7
+	vmovdqu	32(%rcx), %ymm11
+	vmovdqu	64(%rcx), %ymm10
 	vmovdqu	96(%rcx), %ymm8
-	vpsubw	%ymm7, %ymm13, %ymm14
-	vpsubw	%ymm10, %ymm3, %ymm9
-	vpsubw	%ymm4, %ymm6, %ymm12
-	vpaddw	%ymm13, %ymm7, %ymm2
-	vpaddw	%ymm3, %ymm10, %ymm3
-	vpmullw	%ymm14, %ymm1, %ymm11
-	vpaddw	%ymm6, %ymm4, %ymm6
+	vpsubw	%ymm2, %ymm7, %ymm15
+	vpsubw	%ymm3, %ymm11, %ymm9
+	vpsubw	%ymm6, %ymm10, %ymm12
+	vpaddw	%ymm7, %ymm2, %ymm2
+	vpaddw	%ymm11, %ymm3, %ymm3
+	vpmullw	%ymm15, %ymm1, %ymm11
+	vpaddw	%ymm10, %ymm6, %ymm6
 	vpmullw	%ymm9, %ymm1, %ymm13
-	vpsubw	%ymm15, %ymm8, %ymm10
-	vpaddw	%ymm8, %ymm15, %ymm7
+	vpsubw	%ymm4, %ymm8, %ymm10
+	vpaddw	%ymm8, %ymm4, %ymm7
 	vpmullw	%ymm12, %ymm1, %ymm4
 	vpmullw	%ymm10, %ymm1, %ymm8
-	vpmulhw	%ymm14, %ymm5, %ymm15
+	vpmulhw	%ymm15, %ymm5, %ymm15
 	vpmulhw	%ymm9, %ymm5, %ymm9
 	vpmulhw	%ymm12, %ymm5, %ymm12
 	vpmulhw	%ymm10, %ymm5, %ymm10
@@ -13081,13 +12791,13 @@ L_poly_invntt$1:
 	vpsubw	%ymm11, %ymm15, %ymm11
 	vpsubw	%ymm13, %ymm9, %ymm9
 	vpsubw	%ymm4, %ymm12, %ymm12
-	vpsubw	%ymm8, %ymm10, %ymm15
+	vpsubw	%ymm8, %ymm10, %ymm10
 	vmovdqu	glob_data + 1056(%rip), %ymm4
 	vmovdqu	glob_data + 1088(%rip), %ymm8
 	vmovdqu	%ymm11, 256(%rcx)
 	vmovdqu	%ymm9, 288(%rcx)
 	vmovdqu	%ymm12, 320(%rcx)
-	vmovdqu	%ymm15, 352(%rcx)
+	vmovdqu	%ymm10, 352(%rcx)
 	vpmullw	%ymm2, %ymm4, %ymm12
 	vpmulhw	%ymm2, %ymm8, %ymm2
 	vpmulhw	%ymm0, %ymm12, %ymm12
@@ -13113,22 +12823,22 @@ L_poly_invntt$1:
 	vmovdqu	448(%rcx), %ymm12
 	vmovdqu	480(%rcx), %ymm7
 	vmovdqu	128(%rcx), %ymm9
-	vmovdqu	160(%rcx), %ymm13
+	vmovdqu	160(%rcx), %ymm14
 	vmovdqu	192(%rcx), %ymm6
 	vmovdqu	224(%rcx), %ymm11
-	vpsubw	%ymm3, %ymm9, %ymm14
-	vpsubw	%ymm10, %ymm13, %ymm8
+	vpsubw	%ymm3, %ymm9, %ymm15
+	vpsubw	%ymm10, %ymm14, %ymm8
 	vpsubw	%ymm12, %ymm6, %ymm4
 	vpaddw	%ymm9, %ymm3, %ymm2
-	vpaddw	%ymm13, %ymm10, %ymm3
-	vpmullw	%ymm14, %ymm1, %ymm9
+	vpaddw	%ymm14, %ymm10, %ymm3
+	vpmullw	%ymm15, %ymm1, %ymm9
 	vpaddw	%ymm6, %ymm12, %ymm6
 	vpmullw	%ymm8, %ymm1, %ymm13
 	vpsubw	%ymm7, %ymm11, %ymm10
 	vpaddw	%ymm11, %ymm7, %ymm7
 	vpmullw	%ymm4, %ymm1, %ymm12
 	vpmullw	%ymm10, %ymm1, %ymm1
-	vpmulhw	%ymm14, %ymm5, %ymm14
+	vpmulhw	%ymm15, %ymm5, %ymm15
 	vpmulhw	%ymm8, %ymm5, %ymm8
 	vpmulhw	%ymm4, %ymm5, %ymm4
 	vpmulhw	%ymm10, %ymm5, %ymm10
@@ -13136,16 +12846,16 @@ L_poly_invntt$1:
 	vpmulhw	%ymm13, %ymm0, %ymm11
 	vpmulhw	%ymm12, %ymm0, %ymm12
 	vpmulhw	%ymm1, %ymm0, %ymm1
-	vpsubw	%ymm9, %ymm14, %ymm5
+	vpsubw	%ymm9, %ymm15, %ymm5
 	vpsubw	%ymm11, %ymm8, %ymm9
 	vpsubw	%ymm12, %ymm4, %ymm12
-	vpsubw	%ymm1, %ymm10, %ymm15
+	vpsubw	%ymm1, %ymm10, %ymm10
 	vmovdqu	glob_data + 1056(%rip), %ymm4
 	vmovdqu	glob_data + 1088(%rip), %ymm8
 	vmovdqu	%ymm5, 384(%rcx)
 	vmovdqu	%ymm9, 416(%rcx)
 	vmovdqu	%ymm12, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm10, 480(%rcx)
 	vpmullw	%ymm2, %ymm4, %ymm5
 	vpmulhw	%ymm2, %ymm8, %ymm1
 	vpmulhw	%ymm0, %ymm5, %ymm5
@@ -14088,8 +13798,8 @@ L_i_poly_frombytes$1:
 	vpblendw	$170, %ymm11, %ymm4, %ymm11
 	vpsrld	$16, %ymm4, %ymm3
 	vpblendw	$170, %ymm6, %ymm3, %ymm6
-	vpslld	$16, %ymm2, %ymm14
-	vpblendw	$170, %ymm14, %ymm5, %ymm14
+	vpslld	$16, %ymm2, %ymm15
+	vpblendw	$170, %ymm15, %ymm5, %ymm15
 	vpsrld	$16, %ymm5, %ymm3
 	vpblendw	$170, %ymm2, %ymm3, %ymm3
 	vpslld	$16, %ymm1, %ymm2
@@ -14102,10 +13812,10 @@ L_i_poly_frombytes$1:
 	vpand	%ymm11, %ymm0, %ymm2
 	vpand	%ymm12, %ymm0, %ymm12
 	vpsrlw	$8, %ymm6, %ymm4
-	vpsllw	$8, %ymm14, %ymm5
+	vpsllw	$8, %ymm15, %ymm5
 	vpor	%ymm5, %ymm4, %ymm4
 	vpand	%ymm4, %ymm0, %ymm4
-	vpsrlw	$4, %ymm14, %ymm5
+	vpsrlw	$4, %ymm15, %ymm5
 	vpand	%ymm5, %ymm0, %ymm5
 	vpsrlw	$12, %ymm3, %ymm6
 	vpsllw	$4, %ymm8, %ymm7
@@ -14127,31 +13837,31 @@ L_i_poly_frombytes$1:
 	vmovdqu	%ymm7, 192(%rsi)
 	vmovdqu	%ymm8, 224(%rsi)
 	vmovdqu	192(%r9), %ymm2
-	vmovdqu	224(%r9), %ymm3
+	vmovdqu	224(%r9), %ymm1
 	vmovdqu	256(%r9), %ymm4
-	vmovdqu	288(%r9), %ymm1
-	vmovdqu	320(%r9), %ymm5
-	vmovdqu	352(%r9), %ymm7
-	vperm2i128	$32, %ymm1, %ymm2, %ymm8
-	vperm2i128	$49, %ymm1, %ymm2, %ymm6
-	vperm2i128	$32, %ymm5, %ymm3, %ymm1
-	vperm2i128	$49, %ymm5, %ymm3, %ymm9
-	vperm2i128	$32, %ymm7, %ymm4, %ymm5
-	vperm2i128	$49, %ymm7, %ymm4, %ymm7
-	vpunpcklqdq	%ymm9, %ymm8, %ymm10
-	vpunpckhqdq	%ymm9, %ymm8, %ymm2
-	vpunpcklqdq	%ymm5, %ymm6, %ymm3
-	vpunpckhqdq	%ymm5, %ymm6, %ymm5
-	vpunpcklqdq	%ymm7, %ymm1, %ymm6
-	vpunpckhqdq	%ymm7, %ymm1, %ymm1
-	vmovsldup	%ymm5, %ymm11
-	vpblendd	$170, %ymm11, %ymm10, %ymm4
-	vpsrlq	$32, %ymm10, %ymm7
-	vpblendd	$170, %ymm5, %ymm7, %ymm5
+	vmovdqu	288(%r9), %ymm3
+	vmovdqu	320(%r9), %ymm10
+	vmovdqu	352(%r9), %ymm5
+	vperm2i128	$32, %ymm3, %ymm2, %ymm8
+	vperm2i128	$49, %ymm3, %ymm2, %ymm6
+	vperm2i128	$32, %ymm10, %ymm1, %ymm7
+	vperm2i128	$49, %ymm10, %ymm1, %ymm1
+	vperm2i128	$32, %ymm5, %ymm4, %ymm9
+	vperm2i128	$49, %ymm5, %ymm4, %ymm5
+	vpunpcklqdq	%ymm1, %ymm8, %ymm10
+	vpunpckhqdq	%ymm1, %ymm8, %ymm2
+	vpunpcklqdq	%ymm9, %ymm6, %ymm3
+	vpunpckhqdq	%ymm9, %ymm6, %ymm6
+	vpunpcklqdq	%ymm5, %ymm7, %ymm8
+	vpunpckhqdq	%ymm5, %ymm7, %ymm1
 	vmovsldup	%ymm6, %ymm11
-	vpblendd	$170, %ymm11, %ymm2, %ymm7
+	vpblendd	$170, %ymm11, %ymm10, %ymm4
+	vpsrlq	$32, %ymm10, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm5
+	vmovsldup	%ymm8, %ymm6
+	vpblendd	$170, %ymm6, %ymm2, %ymm7
 	vpsrlq	$32, %ymm2, %ymm2
-	vpblendd	$170, %ymm6, %ymm2, %ymm6
+	vpblendd	$170, %ymm8, %ymm2, %ymm6
 	vmovsldup	%ymm1, %ymm2
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
 	vpsrlq	$32, %ymm3, %ymm3
@@ -14160,8 +13870,8 @@ L_i_poly_frombytes$1:
 	vpblendw	$170, %ymm11, %ymm4, %ymm11
 	vpsrld	$16, %ymm4, %ymm3
 	vpblendw	$170, %ymm6, %ymm3, %ymm6
-	vpslld	$16, %ymm2, %ymm14
-	vpblendw	$170, %ymm14, %ymm5, %ymm14
+	vpslld	$16, %ymm2, %ymm15
+	vpblendw	$170, %ymm15, %ymm5, %ymm15
 	vpsrld	$16, %ymm5, %ymm3
 	vpblendw	$170, %ymm2, %ymm3, %ymm3
 	vpslld	$16, %ymm1, %ymm2
@@ -14174,10 +13884,10 @@ L_i_poly_frombytes$1:
 	vpand	%ymm11, %ymm0, %ymm2
 	vpand	%ymm12, %ymm0, %ymm12
 	vpsrlw	$8, %ymm6, %ymm4
-	vpsllw	$8, %ymm14, %ymm5
+	vpsllw	$8, %ymm15, %ymm5
 	vpor	%ymm5, %ymm4, %ymm4
 	vpand	%ymm4, %ymm0, %ymm4
-	vpsrlw	$4, %ymm14, %ymm5
+	vpsrlw	$4, %ymm15, %ymm5
 	vpand	%ymm5, %ymm0, %ymm5
 	vpsrlw	$12, %ymm3, %ymm6
 	vpsllw	$4, %ymm8, %ymm7
@@ -14596,11 +14306,11 @@ L_poly_basemul$1:
 	vpackusdw	%ymm4, %ymm5, %ymm4
 	vpmullw	%ymm1, %ymm6, %ymm5
 	vpmulhw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm7, %ymm5
-	vpmullw	%ymm1, %ymm8, %ymm6
-	vpmulhw	%ymm0, %ymm6, %ymm0
+	vpsubw	%ymm5, %ymm7, %ymm2
+	vpmullw	%ymm1, %ymm8, %ymm5
+	vpmulhw	%ymm0, %ymm5, %ymm0
 	vpsubw	%ymm0, %ymm4, %ymm4
-	vmovdqu	%ymm5, 448(%rcx)
+	vmovdqu	%ymm2, 448(%rcx)
 	vmovdqu	%ymm4, 480(%rcx)
 	ret
 L_poly_csubq$1:
@@ -14779,8 +14489,8 @@ L_shake256_A32__A1600$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14797,19 +14507,19 @@ L_shake256_A32__A1600$1:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdx
 	vpinsrq	$1, %rdx, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -14821,8 +14531,8 @@ L_shake256_A32__A1600$9:
 L_shake256_A32__A1600$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14839,19 +14549,19 @@ L_shake256_A32__A1600$7:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -14884,25 +14594,25 @@ L_shake256_A32__A1600$6:
 	vpxor	%ymm9, %ymm9, %ymm9
 	movq	$0, %rdx
 	vpinsrq	$1, %rdx, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
-	movq	$1, %rdx
-	shlq	$63, %rdx
-	vmovq	%rdx, %xmm7
+	movq	$1, %rcx
+	shlq	$63, %rcx
+	vmovq	%rcx, %xmm7
 	vpxor	%ymm8, %ymm8, %ymm8
 	vinserti128	$0, %xmm7, %ymm8, %ymm8
 	vpxor	%ymm8, %ymm0, %ymm0
@@ -14921,14 +14631,14 @@ L_shake256_A32__A1600$5:
 	movq	%rdi, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm12
-	vmovdqu	%ymm12, 48(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm11
+	vmovdqu	%ymm11, 48(%rsi,%rcx)
 	movq	%xmm9, %rdi
 	movq	%rdi, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm9
+	vpblendd	$195, %ymm12, %ymm8, %ymm9
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdi
 	movq	%rdi, 120(%rsi,%rcx)
@@ -14942,8 +14652,8 @@ L_shake256_A32__A1600$3:
 	call	L_keccakf1600_avx2$1
 L_shake256_A32__A1600$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm4
-	vmovdqu	%xmm4, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm7
+	vmovdqu	%xmm7, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -14958,8 +14668,8 @@ L_sha3_256A_A1568$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14976,19 +14686,19 @@ L_sha3_256A_A1568$1:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15000,8 +14710,8 @@ L_sha3_256A_A1568$9:
 L_sha3_256A_A1568$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -15018,19 +14728,19 @@ L_sha3_256A_A1568$7:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15043,8 +14753,8 @@ L_sha3_256A_A1568$6:
 	jb  	L_sha3_256A_A1568$7
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15063,19 +14773,19 @@ L_sha3_256A_A1568$6:
 	vpxor	%ymm9, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15100,19 +14810,19 @@ L_sha3_256A_A1568$5:
 	movq	%rdi, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm12
-	vmovdqu	%ymm12, 48(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm11
+	vmovdqu	%ymm11, 48(%rsi,%rcx)
 	movq	%xmm9, %rdi
 	movq	%rdi, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm9
+	vpblendd	$195, %ymm12, %ymm8, %ymm9
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
-	movq	%xmm7, %rdi
-	movq	%rdi, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm7
-	movq	%xmm7, 128(%rsi,%rcx)
+	movq	%xmm7, %r8
+	movq	%r8, 120(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm9
+	movq	%xmm9, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_sha3_256A_A1568$3:
@@ -15121,8 +14831,8 @@ L_sha3_256A_A1568$3:
 	call	L_keccakf1600_avx2$1
 L_sha3_256A_A1568$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm4
-	vmovdqu	%xmm4, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm7
+	vmovdqu	%xmm7, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -15340,8 +15050,8 @@ L_shake128x4_absorb_A32_A2$2:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %r9
 	shlq	$63, %r9
-	vmovq	%r9, %xmm4
-	vpbroadcastq	%xmm4, %ymm8
+	vmovq	%r9, %xmm7
+	vpbroadcastq	%xmm7, %ymm8
 	vpxor	640(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 640(%r8)
 	ret
@@ -15411,8 +15121,8 @@ L_shake256x4_A128__A32_A1$7:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %rcx
 	shlq	$63, %rcx
-	vmovq	%rcx, %xmm4
-	vpbroadcastq	%xmm4, %ymm8
+	vmovq	%rcx, %xmm7
+	vpbroadcastq	%xmm7, %ymm8
 	vpxor	512(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 512(%r8)
 	movq	$0, %rcx
@@ -15473,21 +15183,21 @@ L_shake256_A128__A32_A1$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rdi,%rcx), %xmm9
 	movq	24(%rdi,%rcx), %rdx
-	vmovq	%rdx, %xmm7
+	vmovq	%rdx, %xmm10
 	movq	$0, %rdx
-	vpinsrq	$1, %rdx, %xmm7, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm10, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	$0, %rcx
-	vpxor	%ymm7, %ymm7, %ymm7
-	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%ymm9, %ymm9, %ymm9
+	vpxor	%xmm10, %xmm10, %xmm10
 	movq	$0, %rdx
 	movzbq	(%rax,%rcx), %rax
 	orq 	$7936, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm9, %xmm10
-	vinserti128	$1, %xmm10, %ymm7, %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm10, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15500,8 +15210,8 @@ L_shake256_A128__A32_A1$1:
 L_shake256_A128__A32_A1$4:
 	call	L_keccakf1600_avx2$1
 L_shake256_A128__A32_A1$5:
-	vmovdqu	%xmm4, %xmm7
-	movq	%xmm7, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm9
+	movq	%xmm9, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vmovdqu	%xmm5, %xmm9
 	vextracti128	$1, %ymm5, %xmm7
@@ -15509,19 +15219,19 @@ L_shake256_A128__A32_A1$5:
 	movq	%rdx, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm12
-	vmovdqu	%ymm12, 48(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm11
+	vmovdqu	%ymm11, 48(%rsi,%rcx)
 	movq	%xmm9, %rdx
 	movq	%rdx, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm9
+	vpblendd	$195, %ymm12, %ymm8, %ymm9
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdx
 	movq	%rdx, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm7
-	movq	%xmm7, 128(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm9
+	movq	%xmm9, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_shake256_A128__A32_A1$3:
@@ -15537,13 +15247,13 @@ L_shake256_A128__A32_A1$2:
 	movq	%rdx, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
 	vpblendd	$195, %ymm8, %ymm10, %ymm3
 	vmovdqu	%ymm3, 48(%rsi,%rcx)
 	movq	%xmm9, %rdx
 	movq	%rdx, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm3
+	vpblendd	$195, %ymm12, %ymm8, %ymm3
 	vmovdqu	%ymm3, 88(%rsi,%rcx)
 	movq	%xmm7, %rdx
 	movq	%rdx, 120(%rsi,%rcx)
@@ -15559,8 +15269,8 @@ L_sha3_512A_A64$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15579,19 +15289,19 @@ L_sha3_512A_A64$1:
 	vpxor	%ymm9, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15607,19 +15317,19 @@ L_sha3_512A_A64$1:
 L_sha3_512A_A64$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A64$5:
-	vmovdqu	%xmm4, %xmm7
-	movq	%xmm7, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm9
+	movq	%xmm9, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
 	movq	%xmm7, %rdi
 	movq	%rdi, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm7
-	vmovdqu	%xmm7, %xmm8
-	vmovdqu	%xmm8, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm7, %xmm7
-	movq	%xmm7, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm9
+	vmovdqu	%xmm9, %xmm7
+	vmovdqu	%xmm7, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm9, %xmm9
+	movq	%xmm9, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A64$3:
@@ -15650,14 +15360,14 @@ L_sha3_512A_A33$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %xmm9
 	movq	24(%rbp,%rcx), %rdx
-	vmovq	%rdx, %xmm7
+	vmovq	%rdx, %xmm10
 	movq	$0, %rdx
 	movzbq	32(%rbp,%rcx), %rax
 	orq 	$1536, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm7, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm10, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15670,19 +15380,19 @@ L_sha3_512A_A33$1:
 L_sha3_512A_A33$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A33$5:
-	vmovdqu	%xmm4, %xmm7
-	movq	%xmm7, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm9
+	movq	%xmm9, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
-	movq	%xmm7, %r8
-	movq	%r8, 40(%rsi,%rcx)
+	movq	%xmm7, %rdx
+	movq	%rdx, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm7
-	vmovdqu	%xmm7, %xmm8
-	vmovdqu	%xmm8, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm7, %xmm7
-	movq	%xmm7, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm9
+	vmovdqu	%xmm9, %xmm7
+	vmovdqu	%xmm7, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm9, %xmm9
+	movq	%xmm9, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A33$3:
@@ -15984,10 +15694,10 @@ L_keccakf1600_st25_avx2$1:
 	vinserti128	$1, %xmm7, %ymm10, %ymm5
 	vmovdqu	168(%rbx), %ymm6
 	vpblendd	$195, %ymm1, %ymm0, %ymm10
-	vpblendd	$195, %ymm2, %ymm6, %ymm11
+	vpblendd	$195, %ymm2, %ymm6, %ymm12
 	vpblendd	$195, %ymm0, %ymm2, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm0
-	vpblendd	$240, %ymm10, %ymm11, %ymm2
+	vpblendd	$240, %ymm12, %ymm10, %ymm0
+	vpblendd	$240, %ymm10, %ymm12, %ymm2
 	vpblendd	$195, %ymm6, %ymm1, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm1
 	vpblendd	$240, %ymm10, %ymm13, %ymm6
@@ -15996,7 +15706,7 @@ L_keccakf1600_st25_avx2$2:
 	vmovlpd	%xmm4, (%rbx)
 	vmovdqu	%ymm3, 8(%rbx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
 	vextracti128	$1, %ymm5, %xmm7
@@ -16004,13 +15714,13 @@ L_keccakf1600_st25_avx2$2:
 	vpblendd	$195, %ymm8, %ymm10, %ymm0
 	vmovdqu	%ymm0, 48(%rbx)
 	vmovlpd	%xmm5, 80(%rbx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm0
+	vpblendd	$195, %ymm12, %ymm8, %ymm0
 	vmovdqu	%ymm0, 88(%rbx)
 	vmovhpd	%xmm7, 120(%rbx)
 	vpblendd	$195, %ymm10, %ymm13, %ymm0
 	vmovdqu	%ymm0, 128(%rbx)
 	vmovhpd	%xmm5, 160(%rbx)
-	vpblendd	$195, %ymm13, %ymm11, %ymm0
+	vpblendd	$195, %ymm13, %ymm12, %ymm0
 	vmovdqu	%ymm0, 168(%rbx)
 	ret
 L_keccakf1600_avx2$1:
@@ -16111,7 +15821,7 @@ L__keccakf1600_avx2$2:
 	vpblendd	$192, %ymm2, %ymm12, %ymm12
 	vpandn	%ymm12, %ymm5, %ymm5
 	vpxor	%ymm8, %ymm5, %ymm5
-	vpermq	$0, %ymm6, %ymm14
+	vpermq	$0, %ymm6, %ymm15
 	vpermq	$27, %ymm0, %ymm0
 	vpermq	$141, %ymm1, %ymm1
 	vpermq	$114, %ymm9, %ymm6
@@ -16122,7 +15832,7 @@ L__keccakf1600_avx2$2:
 	vpblendd	$192, %ymm8, %ymm2, %ymm2
 	vpblendd	$192, %ymm10, %ymm12, %ymm12
 	vpandn	%ymm12, %ymm2, %ymm2
-	vpxor	%ymm14, %ymm4, %ymm4
+	vpxor	%ymm15, %ymm4, %ymm4
 	vpxor	%ymm7, %ymm3, %ymm3
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpbroadcastq	(%r11,%r12,8), %ymm7
@@ -16156,26 +15866,26 @@ L_nttunpack$1:
 	vpunpckhqdq	%ymm8, %ymm4, %ymm1
 	vpunpcklqdq	%ymm13, %ymm5, %ymm6
 	vpunpckhqdq	%ymm13, %ymm5, %ymm5
-	vmovsldup	%ymm2, %ymm14
-	vpblendd	$170, %ymm14, %ymm7, %ymm4
+	vmovsldup	%ymm2, %ymm15
+	vpblendd	$170, %ymm15, %ymm7, %ymm4
 	vpsrlq	$32, %ymm7, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
-	vmovsldup	%ymm1, %ymm14
-	vpblendd	$170, %ymm14, %ymm9, %ymm3
+	vmovsldup	%ymm1, %ymm15
+	vpblendd	$170, %ymm15, %ymm9, %ymm3
 	vpsrlq	$32, %ymm9, %ymm7
 	vpblendd	$170, %ymm1, %ymm7, %ymm7
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm10, %ymm1
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm10, %ymm1
 	vpsrlq	$32, %ymm10, %ymm9
 	vpblendd	$170, %ymm6, %ymm9, %ymm6
-	vmovsldup	%ymm5, %ymm14
-	vpblendd	$170, %ymm14, %ymm11, %ymm8
+	vmovsldup	%ymm5, %ymm15
+	vpblendd	$170, %ymm15, %ymm11, %ymm8
 	vpsrlq	$32, %ymm11, %ymm9
 	vpblendd	$170, %ymm5, %ymm9, %ymm5
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm4, %ymm0
-	vpsrld	$16, %ymm4, %ymm9
-	vpblendw	$170, %ymm1, %ymm9, %ymm9
+	vpblendw	$170, %ymm11, %ymm4, %ymm9
+	vpsrld	$16, %ymm4, %ymm10
+	vpblendw	$170, %ymm1, %ymm10, %ymm0
 	vpslld	$16, %ymm6, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
 	vpsrld	$16, %ymm2, %ymm10
@@ -16183,83 +15893,83 @@ L_nttunpack$1:
 	vpslld	$16, %ymm8, %ymm2
 	vpblendw	$170, %ymm2, %ymm3, %ymm2
 	vpsrld	$16, %ymm3, %ymm3
-	vpblendw	$170, %ymm8, %ymm3, %ymm4
+	vpblendw	$170, %ymm8, %ymm3, %ymm3
 	vpslld	$16, %ymm5, %ymm6
-	vpblendw	$170, %ymm6, %ymm7, %ymm3
+	vpblendw	$170, %ymm6, %ymm7, %ymm6
 	vpsrld	$16, %ymm7, %ymm7
-	vpblendw	$170, %ymm5, %ymm7, %ymm15
-	vmovdqu	%ymm0, (%rcx)
-	vmovdqu	%ymm9, 32(%rcx)
+	vpblendw	$170, %ymm5, %ymm7, %ymm4
+	vmovdqu	%ymm9, (%rcx)
+	vmovdqu	%ymm0, 32(%rcx)
 	vmovdqu	%ymm1, 64(%rcx)
 	vmovdqu	%ymm13, 96(%rcx)
 	vmovdqu	%ymm2, 128(%rcx)
-	vmovdqu	%ymm4, 160(%rcx)
-	vmovdqu	%ymm3, 192(%rcx)
-	vmovdqu	%ymm15, 224(%rcx)
-	vmovdqu	256(%rcx), %ymm2
-	vmovdqu	288(%rcx), %ymm3
+	vmovdqu	%ymm3, 160(%rcx)
+	vmovdqu	%ymm6, 192(%rcx)
+	vmovdqu	%ymm4, 224(%rcx)
+	vmovdqu	256(%rcx), %ymm3
+	vmovdqu	288(%rcx), %ymm0
 	vmovdqu	320(%rcx), %ymm1
 	vmovdqu	352(%rcx), %ymm8
 	vmovdqu	384(%rcx), %ymm5
-	vmovdqu	416(%rcx), %ymm7
-	vmovdqu	448(%rcx), %ymm4
-	vmovdqu	480(%rcx), %ymm15
-	vperm2i128	$32, %ymm5, %ymm2, %ymm0
-	vperm2i128	$49, %ymm5, %ymm2, %ymm2
-	vperm2i128	$32, %ymm7, %ymm3, %ymm6
-	vperm2i128	$49, %ymm7, %ymm3, %ymm9
-	vperm2i128	$32, %ymm4, %ymm1, %ymm5
-	vperm2i128	$49, %ymm4, %ymm1, %ymm1
-	vperm2i128	$32, %ymm15, %ymm8, %ymm10
-	vperm2i128	$49, %ymm15, %ymm8, %ymm8
-	vpunpcklqdq	%ymm5, %ymm0, %ymm3
-	vpunpckhqdq	%ymm5, %ymm0, %ymm4
-	vpunpcklqdq	%ymm1, %ymm2, %ymm5
-	vpunpckhqdq	%ymm1, %ymm2, %ymm7
-	vpunpcklqdq	%ymm10, %ymm6, %ymm2
-	vpunpckhqdq	%ymm10, %ymm6, %ymm1
-	vpunpcklqdq	%ymm8, %ymm9, %ymm6
-	vpunpckhqdq	%ymm8, %ymm9, %ymm8
+	vmovdqu	416(%rcx), %ymm9
+	vmovdqu	448(%rcx), %ymm6
+	vmovdqu	480(%rcx), %ymm7
+	vperm2i128	$32, %ymm5, %ymm3, %ymm2
+	vperm2i128	$49, %ymm5, %ymm3, %ymm4
+	vperm2i128	$32, %ymm9, %ymm0, %ymm3
+	vperm2i128	$49, %ymm9, %ymm0, %ymm5
+	vperm2i128	$32, %ymm6, %ymm1, %ymm9
+	vperm2i128	$49, %ymm6, %ymm1, %ymm1
+	vperm2i128	$32, %ymm7, %ymm8, %ymm6
+	vperm2i128	$49, %ymm7, %ymm8, %ymm8
+	vpunpcklqdq	%ymm9, %ymm2, %ymm7
+	vpunpckhqdq	%ymm9, %ymm2, %ymm9
+	vpunpcklqdq	%ymm1, %ymm4, %ymm10
+	vpunpckhqdq	%ymm1, %ymm4, %ymm4
+	vpunpcklqdq	%ymm6, %ymm3, %ymm2
+	vpunpckhqdq	%ymm6, %ymm3, %ymm1
+	vpunpcklqdq	%ymm8, %ymm5, %ymm6
+	vpunpckhqdq	%ymm8, %ymm5, %ymm5
 	vmovsldup	%ymm2, %ymm11
-	vpblendd	$170, %ymm11, %ymm3, %ymm9
-	vpsrlq	$32, %ymm3, %ymm3
+	vpblendd	$170, %ymm11, %ymm7, %ymm11
+	vpsrlq	$32, %ymm7, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
-	vmovsldup	%ymm1, %ymm11
-	vpblendd	$170, %ymm11, %ymm4, %ymm3
+	vmovsldup	%ymm1, %ymm15
+	vpblendd	$170, %ymm15, %ymm9, %ymm3
+	vpsrlq	$32, %ymm9, %ymm7
+	vpblendd	$170, %ymm1, %ymm7, %ymm7
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm10, %ymm1
+	vpsrlq	$32, %ymm10, %ymm9
+	vpblendd	$170, %ymm6, %ymm9, %ymm6
+	vmovsldup	%ymm5, %ymm15
+	vpblendd	$170, %ymm15, %ymm4, %ymm8
 	vpsrlq	$32, %ymm4, %ymm4
-	vpblendd	$170, %ymm1, %ymm4, %ymm4
-	vmovsldup	%ymm6, %ymm11
-	vpblendd	$170, %ymm11, %ymm5, %ymm1
-	vpsrlq	$32, %ymm5, %ymm5
-	vpblendd	$170, %ymm6, %ymm5, %ymm5
-	vmovsldup	%ymm8, %ymm6
-	vpblendd	$170, %ymm6, %ymm7, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
-	vpblendd	$170, %ymm8, %ymm7, %ymm7
-	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm9, %ymm0
-	vpsrld	$16, %ymm9, %ymm8
-	vpblendw	$170, %ymm1, %ymm8, %ymm9
-	vpslld	$16, %ymm5, %ymm11
+	vpblendd	$170, %ymm5, %ymm4, %ymm5
+	vpslld	$16, %ymm1, %ymm15
+	vpblendw	$170, %ymm15, %ymm11, %ymm9
+	vpsrld	$16, %ymm11, %ymm10
+	vpblendw	$170, %ymm1, %ymm10, %ymm0
+	vpslld	$16, %ymm6, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
-	vpsrld	$16, %ymm2, %ymm8
-	vpblendw	$170, %ymm5, %ymm8, %ymm8
-	vpslld	$16, %ymm6, %ymm2
+	vpsrld	$16, %ymm2, %ymm10
+	vpblendw	$170, %ymm6, %ymm10, %ymm13
+	vpslld	$16, %ymm8, %ymm2
 	vpblendw	$170, %ymm2, %ymm3, %ymm2
 	vpsrld	$16, %ymm3, %ymm3
-	vpblendw	$170, %ymm6, %ymm3, %ymm10
-	vpslld	$16, %ymm7, %ymm6
-	vpblendw	$170, %ymm6, %ymm4, %ymm3
-	vpsrld	$16, %ymm4, %ymm14
-	vpblendw	$170, %ymm7, %ymm14, %ymm15
-	vmovdqu	%ymm0, 256(%rcx)
-	vmovdqu	%ymm9, 288(%rcx)
+	vpblendw	$170, %ymm8, %ymm3, %ymm3
+	vpslld	$16, %ymm5, %ymm6
+	vpblendw	$170, %ymm6, %ymm7, %ymm6
+	vpsrld	$16, %ymm7, %ymm7
+	vpblendw	$170, %ymm5, %ymm7, %ymm4
+	vmovdqu	%ymm9, 256(%rcx)
+	vmovdqu	%ymm0, 288(%rcx)
 	vmovdqu	%ymm1, 320(%rcx)
-	vmovdqu	%ymm8, 352(%rcx)
+	vmovdqu	%ymm13, 352(%rcx)
 	vmovdqu	%ymm2, 384(%rcx)
-	vmovdqu	%ymm10, 416(%rcx)
-	vmovdqu	%ymm3, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm3, 416(%rcx)
+	vmovdqu	%ymm6, 448(%rcx)
+	vmovdqu	%ymm4, 480(%rcx)
 	ret
 	.data
 	.p2align	5

--- a/code/jasmin/1024/avx2/jkem_pqcp.jazz
+++ b/code/jasmin/1024/avx2/jkem_pqcp.jazz
@@ -17193,9 +17193,10 @@ fn __crypto_kem_dec_jazz (#[spill_to_mmx] reg mut ptr u8[MLKEM_SYMBYTES] shk,
                          reg const ptr u8[MLKEM_SECRETKEYBYTES] sk) -> 
 (reg mut ptr u8[MLKEM_SYMBYTES]) {
   #spill(shk, ct); /* :k */
+  reg u256 z;
+  z = sk.[#unaligned :u256 MLKEM_SECRETKEYBYTES - MLKEM_SYMBYTES]; /* u256 */
   stack u8[MLKEM_SYMBYTES + MLKEM_CIPHERTEXTBYTES] zp_ct;
-  zp_ct[0 : MLKEM_SYMBYTES] =
-    #copy_64(sk[MLKEM_SECRETKEYBYTES - MLKEM_SYMBYTES : MLKEM_SYMBYTES]);
+  zp_ct[:u256 0] = z; /* u256 */
   stack u8[2 * MLKEM_SYMBYTES] buf;
   #[inline]
   buf[0 : MLKEM_INDCPA_MSGBYTES] =

--- a/code/jasmin/1024/avx2/jkem_pqcp.jazz
+++ b/code/jasmin/1024/avx2/jkem_pqcp.jazz
@@ -17179,7 +17179,9 @@ fn __crypto_kem_enc_jazz (reg mut ptr u8[MLKEM_CIPHERTEXTBYTES] ct,
     __indcpa_enc(ct, buf[0 : MLKEM_INDCPA_MSGBYTES], pk,
                  kr[MLKEM_SYMBYTES : MLKEM_SYMBYTES]);
   #unspill(shk); /* :k */
-  shk = #copy_64(kr[0 : MLKEM_SYMBYTES]);
+  reg u256 k;
+  k = kr[:u256 0]; /* u256 */
+  shk[#unaligned :u256 0] = k; /* u256 */
   return ct, shk;
 }
 

--- a/code/jasmin/1024/avx2/jkem_pqcp.jazz
+++ b/code/jasmin/1024/avx2/jkem_pqcp.jazz
@@ -16906,7 +16906,7 @@ fn __indcpa_keypair (#[spill_to_mmx] reg mut ptr u8[MLKEM_PUBLICKEYBYTES] pk,
   reg u64 t64;
   inline int i;
   for i = 0 to MLKEM_SYMBYTES / 8 {
-    t64 = randomnessp[:u64 i]; /* u64 */
+    t64 = randomnessp[#unaligned :u64 i]; /* u64 */
     inbuf[:u64 i] = t64; /* u64 */
   }
   inbuf[32] = (8u) MLKEM_K; /* u8 */
@@ -17150,7 +17150,7 @@ fn __crypto_kem_keypair_jazz (reg mut ptr u8[MLKEM_PUBLICKEYBYTES] pk,
     _sha3_256A_A1568(sk[MLKEM_POLYVECBYTES + MLKEM_PUBLICKEYBYTES : 32], pk);
   randomnessp = s_randomnessp; /* u8[MLKEM_SYMBYTES * 2] */
   for i = 0 to MLKEM_SYMBYTES / 8 {
-    t64 = randomnessp[:u64 MLKEM_SYMBYTES / 8 + i]; /* u64 */
+    t64 = randomnessp[#unaligned :u64 MLKEM_SYMBYTES / 8 + i]; /* u64 */
     sk.[#unaligned :u64 ((MLKEM_POLYVECBYTES + MLKEM_PUBLICKEYBYTES + MLKEM_SYMBYTES) / 8 + i) * 8] =
       t64; /* u64 */
   }
@@ -17167,8 +17167,10 @@ fn __crypto_kem_enc_jazz (reg mut ptr u8[MLKEM_CIPHERTEXTBYTES] ct,
                          reg const ptr u8[MLKEM_SYMBYTES] randomnessp) -> 
 (reg mut ptr u8[MLKEM_CIPHERTEXTBYTES], reg mut ptr u8[MLKEM_SYMBYTES]) {
   #spill(pk, shk); /* :k */
+  reg u256 b;
+  b = randomnessp[#unaligned :u256 0]; /* u256 */
   stack u8[MLKEM_SYMBYTES * 2] buf;
-  buf[0 : MLKEM_SYMBYTES] = #copy_64(randomnessp);
+  buf[:u256 0] = b; /* u256 */
   buf[MLKEM_SYMBYTES : MLKEM_SYMBYTES] =
     _sha3_256A_A1568(buf[MLKEM_SYMBYTES : MLKEM_SYMBYTES], pk);
   stack u8[MLKEM_SYMBYTES * 2] kr;

--- a/code/jasmin/1024/avx2/jkem_pqcp.jazz
+++ b/code/jasmin/1024/avx2/jkem_pqcp.jazz
@@ -17201,8 +17201,10 @@ fn __crypto_kem_dec_jazz (#[spill_to_mmx] reg mut ptr u8[MLKEM_SYMBYTES] shk,
   buf[0 : MLKEM_INDCPA_MSGBYTES] =
     __indcpa_dec(buf[0 : MLKEM_INDCPA_MSGBYTES], ct,
                  sk[0 : MLKEM_POLYVECBYTES]);
-  buf[MLKEM_SYMBYTES : MLKEM_SYMBYTES] =
-    #copy_64(sk[MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES : MLKEM_SYMBYTES]);
+  reg u256 k;
+  k =
+    sk.[#unaligned :u256 MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES]; /* u256 */
+  buf[:u256 1] = k; /* u256 */
   stack u8[2 * MLKEM_SYMBYTES] kr;
   kr = _sha3_512A_A64(kr, buf);
   stack u8[MLKEM_INDCPA_CIPHERTEXTBYTES] ctc;

--- a/code/jasmin/1024/avx2/jkem_pqcp.jazz
+++ b/code/jasmin/1024/avx2/jkem_pqcp.jazz
@@ -17222,7 +17222,12 @@ fn __crypto_kem_dec_jazz (#[spill_to_mmx] reg mut ptr u8[MLKEM_SYMBYTES] shk,
   reg u64 cnd;
   #[inline]
   cnd = __verify(ct, ctc);
-  zp_ct[MLKEM_SYMBYTES : MLKEM_CIPHERTEXTBYTES] = #copy_64(ct);
+  inline int j;
+  for j = 0 to MLKEM_CIPHERTEXTBYTES / 32 {
+    reg u256 c;
+    c = ct[#unaligned :u256 j]; /* u256 */
+    zp_ct[:u256 MLKEM_SYMBYTES / 32 + j] = c; /* u256 */
+  }
   #unspill(shk); /* :k */
   shk = _shake256_A32__A1600(shk, zp_ct);
   #[inline]

--- a/code/jasmin/1024/avx2/jkem_pqcp.s
+++ b/code/jasmin/1024/avx2/jkem_pqcp.s
@@ -6364,14 +6364,8 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$1:
 	vmovdqu	%xmm2, 140(%rax)
 	movd	%xmm3, 156(%rax)
 	movq	%mm1, %rsi
-	movq	64(%rsp), %rcx
-	movq	%rcx, (%rsi)
-	movq	72(%rsp), %rcx
-	movq	%rcx, 8(%rsi)
-	movq	80(%rsp), %rcx
-	movq	%rcx, 16(%rsi)
-	movq	88(%rsp), %rcx
-	movq	%rcx, 24(%rsi)
+	vmovdqu	64(%rsp), %ymm0
+	vmovdqu	%ymm0, (%rsi)
 	xorl	%eax, %eax
 	movq	18592(%rsp), %rbx
 	movq	18600(%rsp), %rbp
@@ -9955,14 +9949,8 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand$1:
 	vmovdqu	%xmm2, 140(%rax)
 	movd	%xmm3, 156(%rax)
 	movq	%mm1, %rsi
-	movq	64(%rsp), %rax
-	movq	%rax, (%rsi)
-	movq	72(%rsp), %rax
-	movq	%rax, 8(%rsi)
-	movq	80(%rsp), %rax
-	movq	%rax, 16(%rsi)
-	movq	88(%rsp), %rax
-	movq	%rax, 24(%rsi)
+	vmovdqu	64(%rsp), %ymm0
+	vmovdqu	%ymm0, (%rsi)
 	xorl	%eax, %eax
 	movq	18592(%rsp), %rbx
 	movq	18600(%rsp), %rbp

--- a/code/jasmin/1024/avx2/jkem_pqcp.s
+++ b/code/jasmin/1024/avx2/jkem_pqcp.s
@@ -22,15 +22,8 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_dec:
 	movq	$0, %rax
 	movq	%rdi, %mm1
 	movq	%rsi, %mm2
-	leaq	3136(%rdx), %rax
-	movq	(%rax), %rcx
-	movq	%rcx, 3744(%rsp)
-	movq	8(%rax), %rcx
-	movq	%rcx, 3752(%rsp)
-	movq	16(%rax), %rcx
-	movq	%rcx, 3760(%rsp)
-	movq	24(%rax), %rcx
-	movq	%rcx, 3768(%rsp)
+	vmovdqu	3136(%rdx), %ymm0
+	vmovdqu	%ymm0, 3744(%rsp)
 	movq	%rsp, %rax
 	movq	%rdx, %r8
 	leaq	5344(%rsp), %r12
@@ -11782,12 +11775,12 @@ L_i_poly_tobytes$2:
 	vpunpckhqdq	%ymm6, %ymm2, %ymm0
 	vpunpcklqdq	%ymm5, %ymm7, %ymm6
 	vpunpckhqdq	%ymm5, %ymm7, %ymm2
-	vpunpcklqdq	%ymm1, %ymm3, %ymm5
+	vpunpcklqdq	%ymm1, %ymm3, %ymm8
 	vpunpckhqdq	%ymm1, %ymm3, %ymm1
 	vperm2i128	$32, %ymm6, %ymm4, %ymm11
 	vperm2i128	$49, %ymm6, %ymm4, %ymm6
-	vperm2i128	$32, %ymm0, %ymm5, %ymm4
-	vperm2i128	$49, %ymm0, %ymm5, %ymm0
+	vperm2i128	$32, %ymm0, %ymm8, %ymm4
+	vperm2i128	$49, %ymm0, %ymm8, %ymm0
 	vperm2i128	$32, %ymm1, %ymm2, %ymm3
 	vperm2i128	$49, %ymm1, %ymm2, %ymm1
 	vmovdqu	%ymm11, (%rsi)
@@ -11854,14 +11847,14 @@ L_i_poly_tobytes$2:
 	vperm2i128	$49, %ymm6, %ymm4, %ymm6
 	vperm2i128	$32, %ymm2, %ymm7, %ymm4
 	vperm2i128	$49, %ymm2, %ymm7, %ymm0
-	vperm2i128	$32, %ymm1, %ymm5, %ymm2
-	vperm2i128	$49, %ymm1, %ymm5, %ymm7
+	vperm2i128	$32, %ymm1, %ymm5, %ymm3
+	vperm2i128	$49, %ymm1, %ymm5, %ymm9
 	vmovdqu	%ymm11, 192(%rsi)
 	vmovdqu	%ymm4, 224(%rsi)
-	vmovdqu	%ymm2, 256(%rsi)
+	vmovdqu	%ymm3, 256(%rsi)
 	vmovdqu	%ymm6, 288(%rsi)
 	vmovdqu	%ymm0, 320(%rsi)
-	vmovdqu	%ymm7, 352(%rsi)
+	vmovdqu	%ymm9, 352(%rsi)
 	ret
 L_poly_sub$1:
 	vmovdqu	(%rsi), %ymm2
@@ -14166,18 +14159,18 @@ L_i_poly_frombytes$1:
 	vperm2i128	$32, %ymm1, %ymm2, %ymm8
 	vperm2i128	$49, %ymm1, %ymm2, %ymm6
 	vperm2i128	$32, %ymm5, %ymm3, %ymm1
-	vperm2i128	$49, %ymm5, %ymm3, %ymm2
+	vperm2i128	$49, %ymm5, %ymm3, %ymm9
 	vperm2i128	$32, %ymm7, %ymm4, %ymm5
 	vperm2i128	$49, %ymm7, %ymm4, %ymm7
-	vpunpcklqdq	%ymm2, %ymm8, %ymm9
-	vpunpckhqdq	%ymm2, %ymm8, %ymm2
+	vpunpcklqdq	%ymm9, %ymm8, %ymm10
+	vpunpckhqdq	%ymm9, %ymm8, %ymm2
 	vpunpcklqdq	%ymm5, %ymm6, %ymm3
 	vpunpckhqdq	%ymm5, %ymm6, %ymm5
 	vpunpcklqdq	%ymm7, %ymm1, %ymm6
 	vpunpckhqdq	%ymm7, %ymm1, %ymm1
 	vmovsldup	%ymm5, %ymm11
-	vpblendd	$170, %ymm11, %ymm9, %ymm4
-	vpsrlq	$32, %ymm9, %ymm7
+	vpblendd	$170, %ymm11, %ymm10, %ymm4
+	vpsrlq	$32, %ymm10, %ymm7
 	vpblendd	$170, %ymm5, %ymm7, %ymm5
 	vmovsldup	%ymm6, %ymm11
 	vpblendd	$170, %ymm11, %ymm2, %ymm7
@@ -14810,8 +14803,8 @@ L_shake256_A32__A1600$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14852,8 +14845,8 @@ L_shake256_A32__A1600$9:
 L_shake256_A32__A1600$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14895,8 +14888,8 @@ L_shake256_A32__A1600$6:
 	jb  	L_shake256_A32__A1600$7
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14931,9 +14924,9 @@ L_shake256_A32__A1600$6:
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
-	movq	$1, %rcx
-	shlq	$63, %rcx
-	vmovq	%rcx, %xmm7
+	movq	$1, %rdx
+	shlq	$63, %rdx
+	vmovq	%rdx, %xmm7
 	vpxor	%ymm8, %ymm8, %ymm8
 	vinserti128	$0, %xmm7, %ymm8, %ymm8
 	vpxor	%ymm8, %ymm0, %ymm0
@@ -14989,8 +14982,8 @@ L_sha3_256A_A1568$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -15015,11 +15008,11 @@ L_sha3_256A_A1568$1:
 	vpblendd	$240, %ymm10, %ymm11, %ymm11
 	vpblendd	$195, %ymm12, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm10
+	vpblendd	$240, %ymm10, %ymm13, %ymm12
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm10, %ymm6, %ymm6
+	vpxor	%ymm12, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15031,8 +15024,8 @@ L_sha3_256A_A1568$9:
 L_sha3_256A_A1568$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -15074,8 +15067,8 @@ L_sha3_256A_A1568$6:
 	jb  	L_sha3_256A_A1568$7
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15142,8 +15135,8 @@ L_sha3_256A_A1568$5:
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdi
 	movq	%rdi, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm9
-	movq	%xmm9, 128(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm7
+	movq	%xmm7, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_sha3_256A_A1568$3:
@@ -15504,21 +15497,21 @@ L_shake256_A128__A32_A1$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rdi,%rcx), %xmm9
 	movq	24(%rdi,%rcx), %rdx
-	vmovq	%rdx, %xmm10
+	vmovq	%rdx, %xmm7
 	movq	$0, %rdx
-	vpinsrq	$1, %rdx, %xmm10, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm7, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	$0, %rcx
-	vpxor	%ymm9, %ymm9, %ymm9
-	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%ymm7, %ymm7, %ymm7
+	vpxor	%xmm9, %xmm9, %xmm9
 	movq	$0, %rdx
 	movzbq	(%rax,%rcx), %rax
 	orq 	$7936, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm10, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm9, %xmm10
+	vinserti128	$1, %xmm10, %ymm7, %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15531,8 +15524,8 @@ L_shake256_A128__A32_A1$1:
 L_shake256_A128__A32_A1$4:
 	call	L_keccakf1600_avx2$1
 L_shake256_A128__A32_A1$5:
-	vmovdqu	%xmm4, %xmm9
-	movq	%xmm9, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm7
+	movq	%xmm7, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vmovdqu	%xmm5, %xmm9
 	vextracti128	$1, %ymm5, %xmm7
@@ -15551,8 +15544,8 @@ L_shake256_A128__A32_A1$5:
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdx
 	movq	%rdx, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm9
-	movq	%xmm9, 128(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm7
+	movq	%xmm7, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_shake256_A128__A32_A1$3:
@@ -15590,8 +15583,8 @@ L_sha3_512A_A64$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15638,19 +15631,19 @@ L_sha3_512A_A64$1:
 L_sha3_512A_A64$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A64$5:
-	vmovdqu	%xmm4, %xmm9
-	movq	%xmm9, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm7
+	movq	%xmm7, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
 	movq	%xmm7, %rdi
 	movq	%rdi, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm9
-	vmovdqu	%xmm9, %xmm7
-	vmovdqu	%xmm7, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm9, %xmm9
-	movq	%xmm9, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm7
+	vmovdqu	%xmm7, %xmm8
+	vmovdqu	%xmm8, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm7, %xmm7
+	movq	%xmm7, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A64$3:
@@ -15681,14 +15674,14 @@ L_sha3_512A_A33$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %xmm9
 	movq	24(%rbp,%rcx), %rdx
-	vmovq	%rdx, %xmm10
+	vmovq	%rdx, %xmm7
 	movq	$0, %rdx
 	movzbq	32(%rbp,%rcx), %rax
 	orq 	$1536, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm10, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm7
-	vpxor	%ymm7, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm7, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm9
+	vpxor	%ymm9, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15701,19 +15694,19 @@ L_sha3_512A_A33$1:
 L_sha3_512A_A33$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A33$5:
-	vmovdqu	%xmm4, %xmm9
-	movq	%xmm9, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm7
+	movq	%xmm7, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
-	movq	%xmm7, %rdx
-	movq	%rdx, 40(%rsi,%rcx)
+	movq	%xmm7, %r8
+	movq	%r8, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm9
-	vmovdqu	%xmm9, %xmm7
-	vmovdqu	%xmm7, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm9, %xmm9
-	movq	%xmm9, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm7
+	vmovdqu	%xmm7, %xmm8
+	vmovdqu	%xmm8, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm7, %xmm7
+	movq	%xmm7, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A33$3:
@@ -16238,7 +16231,7 @@ L_nttunpack$1:
 	vperm2i128	$32, %ymm5, %ymm2, %ymm0
 	vperm2i128	$49, %ymm5, %ymm2, %ymm2
 	vperm2i128	$32, %ymm7, %ymm3, %ymm6
-	vperm2i128	$49, %ymm7, %ymm3, %ymm7
+	vperm2i128	$49, %ymm7, %ymm3, %ymm9
 	vperm2i128	$32, %ymm4, %ymm1, %ymm5
 	vperm2i128	$49, %ymm4, %ymm1, %ymm1
 	vperm2i128	$32, %ymm15, %ymm8, %ymm10
@@ -16246,13 +16239,13 @@ L_nttunpack$1:
 	vpunpcklqdq	%ymm5, %ymm0, %ymm3
 	vpunpckhqdq	%ymm5, %ymm0, %ymm4
 	vpunpcklqdq	%ymm1, %ymm2, %ymm5
-	vpunpckhqdq	%ymm1, %ymm2, %ymm9
+	vpunpckhqdq	%ymm1, %ymm2, %ymm7
 	vpunpcklqdq	%ymm10, %ymm6, %ymm2
 	vpunpckhqdq	%ymm10, %ymm6, %ymm1
-	vpunpcklqdq	%ymm8, %ymm7, %ymm6
-	vpunpckhqdq	%ymm8, %ymm7, %ymm7
+	vpunpcklqdq	%ymm8, %ymm9, %ymm6
+	vpunpckhqdq	%ymm8, %ymm9, %ymm8
 	vmovsldup	%ymm2, %ymm11
-	vpblendd	$170, %ymm11, %ymm3, %ymm10
+	vpblendd	$170, %ymm11, %ymm3, %ymm9
 	vpsrlq	$32, %ymm3, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
 	vmovsldup	%ymm1, %ymm11
@@ -16263,13 +16256,13 @@ L_nttunpack$1:
 	vpblendd	$170, %ymm11, %ymm5, %ymm1
 	vpsrlq	$32, %ymm5, %ymm5
 	vpblendd	$170, %ymm6, %ymm5, %ymm5
-	vmovsldup	%ymm7, %ymm6
-	vpblendd	$170, %ymm6, %ymm9, %ymm6
-	vpsrlq	$32, %ymm9, %ymm9
-	vpblendd	$170, %ymm7, %ymm9, %ymm7
+	vmovsldup	%ymm8, %ymm6
+	vpblendd	$170, %ymm6, %ymm7, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpblendd	$170, %ymm8, %ymm7, %ymm7
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm10, %ymm0
-	vpsrld	$16, %ymm10, %ymm8
+	vpblendw	$170, %ymm11, %ymm9, %ymm0
+	vpsrld	$16, %ymm9, %ymm8
 	vpblendw	$170, %ymm1, %ymm8, %ymm9
 	vpslld	$16, %ymm5, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1

--- a/code/jasmin/1024/avx2/jkem_pqcp.s
+++ b/code/jasmin/1024/avx2/jkem_pqcp.s
@@ -3916,301 +3916,295 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc:
 	movq	%rdi, %rbx
 	movq	%rsi, %r12
 	movq	%rdx, %rbp
-	leaq	18560(%rsp), %rdi
+	movq	%rsp, %rdi
 	movq	$32, %rsi
 	call	__jasmin_syscall_randombytes__
 	movq	%rbp, %mm0
 	movq	%r12, %mm1
-	movq	(%rax), %rcx
-	movq	%rcx, (%rsp)
-	movq	8(%rax), %rcx
-	movq	%rcx, 8(%rsp)
-	movq	16(%rax), %rcx
-	movq	%rcx, 16(%rsp)
-	movq	24(%rax), %rcx
-	movq	%rcx, 24(%rsp)
-	leaq	32(%rsp), %rsi
+	vmovdqu	(%rax), %ymm1
+	vmovdqu	%ymm1, 32(%rsp)
+	leaq	64(%rsp), %rsi
 	call	L_sha3_256A_A1568$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$66:
-	leaq	64(%rsp), %rsi
-	movq	%rsp, %rbp
+	leaq	96(%rsp), %rsi
+	leaq	32(%rsp), %rbp
 	call	L_sha3_512A_A64$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$65:
 	movq	%mm0, %rbp
-	movq	%rsp, %rax
-	leaq	96(%rsp), %rdi
+	leaq	32(%rsp), %rax
+	leaq	128(%rsp), %rdi
 	movq	%rbx, %mm2
 	movq	%rbp, %rcx
-	leaq	2176(%rsp), %rsi
+	leaq	2208(%rsp), %rsi
 	movq	%rcx, %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$64:
-	leaq	2688(%rsp), %rsi
+	leaq	2720(%rsp), %rsi
 	leaq	384(%rcx), %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$63:
-	leaq	3200(%rsp), %rsi
+	leaq	3232(%rsp), %rsi
 	leaq	768(%rcx), %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$62:
-	leaq	3712(%rsp), %rsi
+	leaq	3744(%rsp), %rsi
 	leaq	1152(%rcx), %r9
 	call	L_i_poly_frombytes$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$61:
 	movq	1536(%rbp), %rcx
-	movq	%rcx, 18560(%rsp)
+	movq	%rcx, (%rsp)
 	movq	1544(%rbp), %rcx
-	movq	%rcx, 18568(%rsp)
+	movq	%rcx, 8(%rsp)
 	movq	1552(%rbp), %rcx
-	movq	%rcx, 18576(%rsp)
+	movq	%rcx, 16(%rsp)
 	movq	1560(%rbp), %rcx
-	movq	%rcx, 18584(%rsp)
-	leaq	128(%rsp), %rcx
+	movq	%rcx, 24(%rsp)
+	leaq	160(%rsp), %rcx
 	call	L_i_poly_frommsg$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$60:
 	movq	$1, %rcx
-	leaq	10368(%rsp), %rax
-	leaq	18560(%rsp), %rdx
+	leaq	10400(%rsp), %rax
+	movq	%rsp, %rdx
 	leaq	-2168(%rsp), %rsp
 	call	L_gen_matrix_avx2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$59:
 	leaq	2168(%rsp), %rsp
 	movb	$0, %r9b
-	leaq	4224(%rsp), %rax
-	leaq	4736(%rsp), %rcx
-	leaq	5248(%rsp), %rdx
-	leaq	5760(%rsp), %r8
+	leaq	4256(%rsp), %rax
+	leaq	4768(%rsp), %rcx
+	leaq	5280(%rsp), %rdx
+	leaq	5792(%rsp), %r8
 	leaq	-600(%rsp), %rsp
 	call	L_poly_getnoise_eta1_4x$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$58:
 	leaq	600(%rsp), %rsp
 	movb	$4, %r9b
-	leaq	6272(%rsp), %rax
-	leaq	6784(%rsp), %rcx
-	leaq	7296(%rsp), %rdx
-	leaq	7808(%rsp), %r8
+	leaq	6304(%rsp), %rax
+	leaq	6816(%rsp), %rcx
+	leaq	7328(%rsp), %rdx
+	leaq	7840(%rsp), %r8
 	leaq	-600(%rsp), %rsp
 	call	L_poly_getnoise_eta1_4x$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$57:
 	leaq	600(%rsp), %rsp
 	movb	$8, %al
-	leaq	640(%rsp), %rcx
+	leaq	672(%rsp), %rcx
 	leaq	-184(%rsp), %rsp
 	call	L_poly_getnoise_eta2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$56:
 	leaq	184(%rsp), %rsp
-	leaq	4224(%rsp), %rcx
+	leaq	4256(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$55:
-	leaq	4736(%rsp), %rcx
+	leaq	4768(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$54:
-	leaq	5248(%rsp), %rcx
+	leaq	5280(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$53:
-	leaq	5760(%rsp), %rcx
+	leaq	5792(%rsp), %rcx
 	call	L_poly_ntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$52:
-	leaq	8320(%rsp), %rcx
-	leaq	10368(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	10400(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$51:
-	leaq	1152(%rsp), %rcx
-	leaq	10880(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	10912(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$50:
-	leaq	8320(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$49:
-	leaq	1152(%rsp), %rcx
-	leaq	11392(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	11424(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$48:
-	leaq	8320(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$47:
-	leaq	1152(%rsp), %rcx
-	leaq	11904(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	11936(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$46:
-	leaq	8320(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$45:
-	leaq	8832(%rsp), %rcx
-	leaq	12416(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	12448(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$44:
-	leaq	1152(%rsp), %rcx
-	leaq	12928(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	12960(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$43:
-	leaq	8832(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$42:
-	leaq	1152(%rsp), %rcx
-	leaq	13440(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	13472(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$41:
-	leaq	8832(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$40:
-	leaq	1152(%rsp), %rcx
-	leaq	13952(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	13984(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$39:
-	leaq	8832(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$38:
-	leaq	9344(%rsp), %rcx
-	leaq	14464(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	14496(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$37:
-	leaq	1152(%rsp), %rcx
-	leaq	14976(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	15008(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$36:
-	leaq	9344(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$35:
-	leaq	1152(%rsp), %rcx
-	leaq	15488(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	15520(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$34:
-	leaq	9344(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$33:
-	leaq	1152(%rsp), %rcx
-	leaq	16000(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	16032(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$32:
-	leaq	9344(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$31:
-	leaq	9856(%rsp), %rcx
-	leaq	16512(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	16544(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$30:
-	leaq	1152(%rsp), %rcx
-	leaq	17024(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	17056(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$29:
-	leaq	9856(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$28:
-	leaq	1152(%rsp), %rcx
-	leaq	17536(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	17568(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$27:
-	leaq	9856(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$26:
-	leaq	1152(%rsp), %rcx
-	leaq	18048(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	18080(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$25:
-	leaq	9856(%rsp), %rcx
-	leaq	1152(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	1184(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$24:
-	leaq	1152(%rsp), %rcx
-	leaq	2176(%rsp), %rsi
-	leaq	4224(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	2208(%rsp), %rsi
+	leaq	4256(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$23:
-	leaq	1664(%rsp), %rcx
-	leaq	2688(%rsp), %rsi
-	leaq	4736(%rsp), %rdi
+	leaq	1696(%rsp), %rcx
+	leaq	2720(%rsp), %rsi
+	leaq	4768(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$22:
-	leaq	1152(%rsp), %rcx
-	leaq	1664(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	1696(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$21:
-	leaq	1664(%rsp), %rcx
-	leaq	3200(%rsp), %rsi
-	leaq	5248(%rsp), %rdi
+	leaq	1696(%rsp), %rcx
+	leaq	3232(%rsp), %rsi
+	leaq	5280(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$20:
-	leaq	1152(%rsp), %rcx
-	leaq	1664(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	1696(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$19:
-	leaq	1664(%rsp), %rcx
-	leaq	3712(%rsp), %rsi
-	leaq	5760(%rsp), %rdi
+	leaq	1696(%rsp), %rcx
+	leaq	3744(%rsp), %rsi
+	leaq	5792(%rsp), %rdi
 	call	L_poly_basemul$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$18:
-	leaq	1152(%rsp), %rcx
-	leaq	1664(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	1696(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$17:
-	leaq	8320(%rsp), %rcx
+	leaq	8352(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$16:
-	leaq	8832(%rsp), %rcx
+	leaq	8864(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$15:
-	leaq	9344(%rsp), %rcx
+	leaq	9376(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$14:
-	leaq	9856(%rsp), %rcx
+	leaq	9888(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$13:
-	leaq	1152(%rsp), %rcx
+	leaq	1184(%rsp), %rcx
 	call	L_poly_invntt$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$12:
-	leaq	8320(%rsp), %rcx
-	leaq	6272(%rsp), %rdi
+	leaq	8352(%rsp), %rcx
+	leaq	6304(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$11:
-	leaq	8832(%rsp), %rcx
-	leaq	6784(%rsp), %rdi
+	leaq	8864(%rsp), %rcx
+	leaq	6816(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$10:
-	leaq	9344(%rsp), %rcx
-	leaq	7296(%rsp), %rdi
+	leaq	9376(%rsp), %rcx
+	leaq	7328(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$9:
-	leaq	9856(%rsp), %rcx
-	leaq	7808(%rsp), %rdi
+	leaq	9888(%rsp), %rcx
+	leaq	7840(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$8:
-	leaq	1152(%rsp), %rcx
-	leaq	640(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	672(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$7:
-	leaq	1152(%rsp), %rcx
-	leaq	128(%rsp), %rdi
+	leaq	1184(%rsp), %rcx
+	leaq	160(%rsp), %rdi
 	call	L_poly_add2$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
-	leaq	8320(%rsp), %rax
+	leaq	8352(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4309,7 +4303,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	8832(%rsp), %rax
+	leaq	8864(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4408,7 +4402,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	9344(%rsp), %rax
+	leaq	9376(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4507,7 +4501,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	9856(%rsp), %rax
+	leaq	9888(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4606,7 +4600,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vpmullw	%ymm0, %ymm4, %ymm4
 	vpsubw	%ymm4, %ymm2, %ymm1
 	vmovdqu	%ymm1, 480(%rax)
-	leaq	1152(%rsp), %rax
+	leaq	1184(%rsp), %rax
 	vmovdqu	glob_data + 1184(%rip), %ymm0
 	vmovdqu	glob_data + 1120(%rip), %ymm1
 	vmovdqu	(%rax), %ymm2
@@ -4707,16 +4701,16 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$6:
 	vmovdqu	%ymm1, 480(%rax)
 	movq	%mm2, %rbx
 	movq	%rbx, %rax
-	leaq	8320(%rsp), %rcx
+	leaq	8352(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$5:
-	leaq	8832(%rsp), %rcx
+	leaq	8864(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$4:
-	leaq	9344(%rsp), %rcx
+	leaq	9376(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$3:
-	leaq	9856(%rsp), %rcx
+	leaq	9888(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vmovdqu	glob_data + 1120(%rip), %ymm0
@@ -4728,7 +4722,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpbroadcastq	glob_data + 4960(%rip), %ymm6
 	vmovdqu	glob_data + 160(%rip), %ymm7
 	vmovdqu	glob_data + 128(%rip), %ymm8
-	vmovdqu	8320(%rsp), %ymm9
+	vmovdqu	8352(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4751,7 +4745,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, (%rax)
 	movq	%xmm9, 16(%rax)
-	vmovdqu	8352(%rsp), %ymm9
+	vmovdqu	8384(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4774,7 +4768,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 22(%rax)
 	movq	%xmm9, 38(%rax)
-	vmovdqu	8384(%rsp), %ymm9
+	vmovdqu	8416(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4797,7 +4791,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 44(%rax)
 	movq	%xmm9, 60(%rax)
-	vmovdqu	8416(%rsp), %ymm9
+	vmovdqu	8448(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4820,7 +4814,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 66(%rax)
 	movq	%xmm9, 82(%rax)
-	vmovdqu	8448(%rsp), %ymm9
+	vmovdqu	8480(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4843,7 +4837,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 88(%rax)
 	movq	%xmm9, 104(%rax)
-	vmovdqu	8480(%rsp), %ymm9
+	vmovdqu	8512(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4866,7 +4860,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 110(%rax)
 	movq	%xmm9, 126(%rax)
-	vmovdqu	8512(%rsp), %ymm9
+	vmovdqu	8544(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4889,7 +4883,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 132(%rax)
 	movq	%xmm9, 148(%rax)
-	vmovdqu	8544(%rsp), %ymm9
+	vmovdqu	8576(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4912,7 +4906,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 154(%rax)
 	movq	%xmm9, 170(%rax)
-	vmovdqu	8576(%rsp), %ymm9
+	vmovdqu	8608(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4935,7 +4929,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 176(%rax)
 	movq	%xmm9, 192(%rax)
-	vmovdqu	8608(%rsp), %ymm9
+	vmovdqu	8640(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4958,7 +4952,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 198(%rax)
 	movq	%xmm9, 214(%rax)
-	vmovdqu	8640(%rsp), %ymm9
+	vmovdqu	8672(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -4981,7 +4975,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 220(%rax)
 	movq	%xmm9, 236(%rax)
-	vmovdqu	8672(%rsp), %ymm9
+	vmovdqu	8704(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5004,7 +4998,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 242(%rax)
 	movq	%xmm9, 258(%rax)
-	vmovdqu	8704(%rsp), %ymm9
+	vmovdqu	8736(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5027,7 +5021,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 264(%rax)
 	movq	%xmm9, 280(%rax)
-	vmovdqu	8736(%rsp), %ymm9
+	vmovdqu	8768(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5050,7 +5044,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 286(%rax)
 	movq	%xmm9, 302(%rax)
-	vmovdqu	8768(%rsp), %ymm9
+	vmovdqu	8800(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5073,7 +5067,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 308(%rax)
 	movq	%xmm9, 324(%rax)
-	vmovdqu	8800(%rsp), %ymm9
+	vmovdqu	8832(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5096,7 +5090,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 330(%rax)
 	movq	%xmm9, 346(%rax)
-	vmovdqu	8832(%rsp), %ymm9
+	vmovdqu	8864(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5119,7 +5113,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 352(%rax)
 	movq	%xmm9, 368(%rax)
-	vmovdqu	8864(%rsp), %ymm9
+	vmovdqu	8896(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5142,7 +5136,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 374(%rax)
 	movq	%xmm9, 390(%rax)
-	vmovdqu	8896(%rsp), %ymm9
+	vmovdqu	8928(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5165,7 +5159,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 396(%rax)
 	movq	%xmm9, 412(%rax)
-	vmovdqu	8928(%rsp), %ymm9
+	vmovdqu	8960(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5188,7 +5182,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 418(%rax)
 	movq	%xmm9, 434(%rax)
-	vmovdqu	8960(%rsp), %ymm9
+	vmovdqu	8992(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5211,7 +5205,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 440(%rax)
 	movq	%xmm9, 456(%rax)
-	vmovdqu	8992(%rsp), %ymm9
+	vmovdqu	9024(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5234,7 +5228,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 462(%rax)
 	movq	%xmm9, 478(%rax)
-	vmovdqu	9024(%rsp), %ymm9
+	vmovdqu	9056(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5257,7 +5251,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 484(%rax)
 	movq	%xmm9, 500(%rax)
-	vmovdqu	9056(%rsp), %ymm9
+	vmovdqu	9088(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5280,7 +5274,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 506(%rax)
 	movq	%xmm9, 522(%rax)
-	vmovdqu	9088(%rsp), %ymm9
+	vmovdqu	9120(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5303,7 +5297,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 528(%rax)
 	movq	%xmm9, 544(%rax)
-	vmovdqu	9120(%rsp), %ymm9
+	vmovdqu	9152(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5326,7 +5320,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 550(%rax)
 	movq	%xmm9, 566(%rax)
-	vmovdqu	9152(%rsp), %ymm9
+	vmovdqu	9184(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5349,7 +5343,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 572(%rax)
 	movq	%xmm9, 588(%rax)
-	vmovdqu	9184(%rsp), %ymm9
+	vmovdqu	9216(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5372,7 +5366,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 594(%rax)
 	movq	%xmm9, 610(%rax)
-	vmovdqu	9216(%rsp), %ymm9
+	vmovdqu	9248(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5395,7 +5389,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 616(%rax)
 	movq	%xmm9, 632(%rax)
-	vmovdqu	9248(%rsp), %ymm9
+	vmovdqu	9280(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5418,7 +5412,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 638(%rax)
 	movq	%xmm9, 654(%rax)
-	vmovdqu	9280(%rsp), %ymm9
+	vmovdqu	9312(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5441,7 +5435,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 660(%rax)
 	movq	%xmm9, 676(%rax)
-	vmovdqu	9312(%rsp), %ymm9
+	vmovdqu	9344(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5464,7 +5458,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 682(%rax)
 	movq	%xmm9, 698(%rax)
-	vmovdqu	9344(%rsp), %ymm9
+	vmovdqu	9376(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5487,7 +5481,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 704(%rax)
 	movq	%xmm9, 720(%rax)
-	vmovdqu	9376(%rsp), %ymm9
+	vmovdqu	9408(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5510,7 +5504,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 726(%rax)
 	movq	%xmm9, 742(%rax)
-	vmovdqu	9408(%rsp), %ymm9
+	vmovdqu	9440(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5533,7 +5527,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 748(%rax)
 	movq	%xmm9, 764(%rax)
-	vmovdqu	9440(%rsp), %ymm9
+	vmovdqu	9472(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5556,7 +5550,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 770(%rax)
 	movq	%xmm9, 786(%rax)
-	vmovdqu	9472(%rsp), %ymm9
+	vmovdqu	9504(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5579,7 +5573,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 792(%rax)
 	movq	%xmm9, 808(%rax)
-	vmovdqu	9504(%rsp), %ymm9
+	vmovdqu	9536(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5602,7 +5596,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 814(%rax)
 	movq	%xmm9, 830(%rax)
-	vmovdqu	9536(%rsp), %ymm9
+	vmovdqu	9568(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5625,7 +5619,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 836(%rax)
 	movq	%xmm9, 852(%rax)
-	vmovdqu	9568(%rsp), %ymm9
+	vmovdqu	9600(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5648,7 +5642,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 858(%rax)
 	movq	%xmm9, 874(%rax)
-	vmovdqu	9600(%rsp), %ymm9
+	vmovdqu	9632(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5671,7 +5665,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 880(%rax)
 	movq	%xmm9, 896(%rax)
-	vmovdqu	9632(%rsp), %ymm9
+	vmovdqu	9664(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5694,7 +5688,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 902(%rax)
 	movq	%xmm9, 918(%rax)
-	vmovdqu	9664(%rsp), %ymm9
+	vmovdqu	9696(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5717,7 +5711,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 924(%rax)
 	movq	%xmm9, 940(%rax)
-	vmovdqu	9696(%rsp), %ymm9
+	vmovdqu	9728(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5740,7 +5734,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 946(%rax)
 	movq	%xmm9, 962(%rax)
-	vmovdqu	9728(%rsp), %ymm9
+	vmovdqu	9760(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5763,7 +5757,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 968(%rax)
 	movq	%xmm9, 984(%rax)
-	vmovdqu	9760(%rsp), %ymm9
+	vmovdqu	9792(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5786,7 +5780,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 990(%rax)
 	movq	%xmm9, 1006(%rax)
-	vmovdqu	9792(%rsp), %ymm9
+	vmovdqu	9824(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5809,7 +5803,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1012(%rax)
 	movq	%xmm9, 1028(%rax)
-	vmovdqu	9824(%rsp), %ymm9
+	vmovdqu	9856(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5832,7 +5826,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1034(%rax)
 	movq	%xmm9, 1050(%rax)
-	vmovdqu	9856(%rsp), %ymm9
+	vmovdqu	9888(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5855,7 +5849,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1056(%rax)
 	movq	%xmm9, 1072(%rax)
-	vmovdqu	9888(%rsp), %ymm9
+	vmovdqu	9920(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5878,7 +5872,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1078(%rax)
 	movq	%xmm9, 1094(%rax)
-	vmovdqu	9920(%rsp), %ymm9
+	vmovdqu	9952(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5901,7 +5895,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1100(%rax)
 	movq	%xmm9, 1116(%rax)
-	vmovdqu	9952(%rsp), %ymm9
+	vmovdqu	9984(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5924,7 +5918,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1122(%rax)
 	movq	%xmm9, 1138(%rax)
-	vmovdqu	9984(%rsp), %ymm9
+	vmovdqu	10016(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5947,7 +5941,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1144(%rax)
 	movq	%xmm9, 1160(%rax)
-	vmovdqu	10016(%rsp), %ymm9
+	vmovdqu	10048(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5970,7 +5964,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1166(%rax)
 	movq	%xmm9, 1182(%rax)
-	vmovdqu	10048(%rsp), %ymm9
+	vmovdqu	10080(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -5993,7 +5987,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1188(%rax)
 	movq	%xmm9, 1204(%rax)
-	vmovdqu	10080(%rsp), %ymm9
+	vmovdqu	10112(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6016,7 +6010,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1210(%rax)
 	movq	%xmm9, 1226(%rax)
-	vmovdqu	10112(%rsp), %ymm9
+	vmovdqu	10144(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6039,7 +6033,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1232(%rax)
 	movq	%xmm9, 1248(%rax)
-	vmovdqu	10144(%rsp), %ymm9
+	vmovdqu	10176(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6062,7 +6056,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1254(%rax)
 	movq	%xmm9, 1270(%rax)
-	vmovdqu	10176(%rsp), %ymm9
+	vmovdqu	10208(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6085,7 +6079,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1276(%rax)
 	movq	%xmm9, 1292(%rax)
-	vmovdqu	10208(%rsp), %ymm9
+	vmovdqu	10240(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6108,7 +6102,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1298(%rax)
 	movq	%xmm9, 1314(%rax)
-	vmovdqu	10240(%rsp), %ymm9
+	vmovdqu	10272(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6131,7 +6125,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1320(%rax)
 	movq	%xmm9, 1336(%rax)
-	vmovdqu	10272(%rsp), %ymm9
+	vmovdqu	10304(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6154,7 +6148,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1342(%rax)
 	movq	%xmm9, 1358(%rax)
-	vmovdqu	10304(%rsp), %ymm9
+	vmovdqu	10336(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6177,7 +6171,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vpblendvb	%xmm8, %xmm9, %xmm11, %xmm11
 	vmovdqu	%xmm11, 1364(%rax)
 	movq	%xmm9, 1380(%rax)
-	vmovdqu	10336(%rsp), %ymm9
+	vmovdqu	10368(%rsp), %ymm9
 	vpmullw	%ymm1, %ymm9, %ymm10
 	vpaddw	%ymm2, %ymm9, %ymm11
 	vpsllw	$3, %ymm9, %ymm9
@@ -6201,7 +6195,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$2:
 	vmovdqu	%xmm2, 1386(%rax)
 	movq	%xmm3, 1402(%rax)
 	leaq	1408(%rbx), %rax
-	leaq	1152(%rsp), %rcx
+	leaq	1184(%rsp), %rcx
 	call	L_poly_csubq$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$1:
 	vmovdqu	glob_data + 1120(%rip), %ymm0
@@ -6364,7 +6358,7 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc$1:
 	vmovdqu	%xmm2, 140(%rax)
 	movd	%xmm3, 156(%rax)
 	movq	%mm1, %rsi
-	vmovdqu	64(%rsp), %ymm0
+	vmovdqu	96(%rsp), %ymm0
 	vmovdqu	%ymm0, (%rsi)
 	xorl	%eax, %eax
 	movq	18592(%rsp), %rbx
@@ -7506,14 +7500,8 @@ jade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand:
 	movq	%rdx, %rbp
 	movq	%rbp, %mm0
 	movq	%rsi, %mm1
-	movq	(%rcx), %rax
-	movq	%rax, (%rsp)
-	movq	8(%rcx), %rax
-	movq	%rax, 8(%rsp)
-	movq	16(%rcx), %rax
-	movq	%rax, 16(%rsp)
-	movq	24(%rcx), %rax
-	movq	%rax, 24(%rsp)
+	vmovdqu	(%rcx), %ymm1
+	vmovdqu	%ymm1, (%rsp)
 	leaq	32(%rsp), %rsi
 	call	L_sha3_256A_A1568$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_enc_derand$66:

--- a/code/jasmin/1024/avx2/jkem_pqcp.s
+++ b/code/jasmin/1024/avx2/jkem_pqcp.s
@@ -856,15 +856,8 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_dec$68:
 	leaq	1152(%rsp), %rcx
 	call	L_i_poly_tomsg$1
 Ljade_kem_mlkem_mlkem1024_amd64_avx2_dec$67:
-	leaq	3104(%rdx), %rax
-	movq	(%rax), %rcx
-	movq	%rcx, 32(%rsp)
-	movq	8(%rax), %rcx
-	movq	%rcx, 40(%rsp)
-	movq	16(%rax), %rcx
-	movq	%rcx, 48(%rsp)
-	movq	24(%rax), %rcx
-	movq	%rcx, 56(%rsp)
+	vmovdqu	3104(%rdx), %ymm0
+	vmovdqu	%ymm0, 32(%rsp)
 	leaq	64(%rsp), %rsi
 	movq	%rsp, %rbp
 	call	L_sha3_512A_A64$1
@@ -11393,12 +11386,12 @@ L_gen_matrix_buf_rejection$14:
 	cmovnbe	%r12, %r11
 	vmovdqu	%xmm4, (%r9,%rbp,2)
 L_gen_matrix_buf_rejection$15:
-	vextracti128	$1, %ymm3, %xmm4
+	vextracti128	$1, %ymm3, %xmm3
 	cmpq	$248, %r13
 	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	movq	%xmm4, %r12
+	movq	%xmm3, %r12
 	cmpq	$252, %r13
 	jbe 	L_gen_matrix_buf_rejection$12
 	movq	$-1, %rbp
@@ -11408,7 +11401,7 @@ L_gen_matrix_buf_rejection$12:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
 	movq	%r12, (%r9,%r13,2)
-	vpextrq	$1, %xmm4, %r12
+	vpextrq	$1, %xmm3, %r12
 	addq	$4, %r13
 L_gen_matrix_buf_rejection$13:
 	cmpq	$254, %r13
@@ -11437,7 +11430,7 @@ L_gen_matrix_buf_rejection$9:
 L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
-	vmovdqu	%xmm4, (%r9,%r13,2)
+	vmovdqu	%xmm3, (%r9,%r13,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r14, %rbp
 	movq	8(%rsp), %r13
@@ -11862,13 +11855,13 @@ L_i_poly_tobytes$2:
 	vperm2i128	$32, %ymm2, %ymm7, %ymm4
 	vperm2i128	$49, %ymm2, %ymm7, %ymm0
 	vperm2i128	$32, %ymm1, %ymm5, %ymm2
-	vperm2i128	$49, %ymm1, %ymm5, %ymm1
+	vperm2i128	$49, %ymm1, %ymm5, %ymm7
 	vmovdqu	%ymm11, 192(%rsi)
 	vmovdqu	%ymm4, 224(%rsi)
 	vmovdqu	%ymm2, 256(%rsi)
 	vmovdqu	%ymm6, 288(%rsi)
 	vmovdqu	%ymm0, 320(%rsi)
-	vmovdqu	%ymm1, 352(%rsi)
+	vmovdqu	%ymm7, 352(%rsi)
 	ret
 L_poly_sub$1:
 	vmovdqu	(%rsi), %ymm2
@@ -12013,27 +12006,26 @@ L_poly_ntt$1:
 	vpsubw	%ymm5, %ymm1, %ymm12
 	vpaddw	%ymm1, %ymm5, %ymm1
 	vpaddw	%ymm9, %ymm2, %ymm5
-	vpsubw	%ymm2, %ymm8, %ymm9
-	vpaddw	%ymm13, %ymm4, %ymm8
+	vpsubw	%ymm2, %ymm8, %ymm8
+	vpaddw	%ymm13, %ymm4, %ymm9
 	vpsubw	%ymm4, %ymm6, %ymm6
 	vpaddw	%ymm12, %ymm10, %ymm4
 	vpsubw	%ymm10, %ymm1, %ymm12
 	vpaddw	%ymm7, %ymm11, %ymm15
 	vpsubw	%ymm11, %ymm3, %ymm13
 	vmovdqu	%ymm5, 384(%rcx)
-	vmovdqu	%ymm8, 416(%rcx)
+	vmovdqu	%ymm9, 416(%rcx)
 	vmovdqu	%ymm4, 448(%rcx)
 	vmovdqu	%ymm15, 480(%rcx)
 	vpbroadcastd	glob_data + 2024(%rip), %ymm2
 	vpbroadcastd	glob_data + 2028(%rip), %ymm4
-	vmovdqu	%ymm9, %ymm11
 	vmovdqu	%ymm6, %ymm10
 	vmovdqu	(%rcx), %ymm9
 	vmovdqu	32(%rcx), %ymm6
 	vmovdqu	64(%rcx), %ymm7
 	vmovdqu	96(%rcx), %ymm5
-	vpmullw	%ymm11, %ymm2, %ymm15
-	vpmulhw	%ymm11, %ymm4, %ymm3
+	vpmullw	%ymm8, %ymm2, %ymm15
+	vpmulhw	%ymm8, %ymm4, %ymm3
 	vpmullw	%ymm10, %ymm2, %ymm11
 	vpmulhw	%ymm10, %ymm4, %ymm10
 	vpmullw	%ymm12, %ymm2, %ymm1
@@ -12303,7 +12295,7 @@ L_poly_ntt$1:
 	vmovdqu	%ymm15, 224(%rcx)
 	vpbroadcastd	glob_data + 2416(%rip), %ymm2
 	vpbroadcastd	glob_data + 2420(%rip), %ymm6
-	vmovdqu	384(%rcx), %ymm15
+	vmovdqu	384(%rcx), %ymm8
 	vmovdqu	416(%rcx), %ymm13
 	vmovdqu	448(%rcx), %ymm5
 	vmovdqu	480(%rcx), %ymm7
@@ -12311,8 +12303,8 @@ L_poly_ntt$1:
 	vmovdqu	288(%rcx), %ymm3
 	vmovdqu	320(%rcx), %ymm12
 	vmovdqu	352(%rcx), %ymm4
-	vpmullw	%ymm15, %ymm2, %ymm11
-	vpmulhw	%ymm15, %ymm6, %ymm10
+	vpmullw	%ymm8, %ymm2, %ymm11
+	vpmulhw	%ymm8, %ymm6, %ymm10
 	vpmullw	%ymm13, %ymm2, %ymm8
 	vpmulhw	%ymm13, %ymm6, %ymm15
 	vpmullw	%ymm5, %ymm2, %ymm1
@@ -12829,8 +12821,8 @@ L_poly_invntt$1:
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm9
-	vmovdqu	%ymm9, (%rcx)
+	vpsubw	%ymm5, %ymm9, %ymm1
+	vmovdqu	%ymm1, (%rcx)
 	vmovdqu	%ymm10, 32(%rcx)
 	vmovdqu	%ymm2, 64(%rcx)
 	vmovdqu	%ymm3, 96(%rcx)
@@ -12866,11 +12858,11 @@ L_poly_invntt$1:
 	vpmulhw	%ymm7, %ymm2, %ymm7
 	vpmulhw	%ymm8, %ymm5, %ymm2
 	vpmulhw	%ymm10, %ymm5, %ymm10
-	vpmulhw	%ymm9, %ymm0, %ymm9
+	vpmulhw	%ymm9, %ymm0, %ymm8
 	vpmulhw	%ymm13, %ymm0, %ymm13
 	vpmulhw	%ymm12, %ymm0, %ymm5
 	vpmulhw	%ymm1, %ymm0, %ymm1
-	vpsubw	%ymm9, %ymm15, %ymm12
+	vpsubw	%ymm8, %ymm15, %ymm12
 	vpsubw	%ymm13, %ymm7, %ymm8
 	vpsubw	%ymm5, %ymm2, %ymm9
 	vpsubw	%ymm1, %ymm10, %ymm7
@@ -13084,7 +13076,7 @@ L_poly_invntt$1:
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm9
+	vpsubw	%ymm5, %ymm9, %ymm7
 	vmovdqu	%ymm6, 384(%rcx)
 	vmovdqu	%ymm8, 416(%rcx)
 	vmovdqu	%ymm4, 448(%rcx)
@@ -13093,15 +13085,14 @@ L_poly_invntt$1:
 	vpbroadcastd	glob_data + 2004(%rip), %ymm5
 	vmovdqu	%ymm3, %ymm15
 	vmovdqu	%ymm2, %ymm4
-	vmovdqu	%ymm9, %ymm2
 	vmovdqu	(%rcx), %ymm13
 	vmovdqu	32(%rcx), %ymm3
 	vmovdqu	64(%rcx), %ymm6
 	vmovdqu	96(%rcx), %ymm8
-	vpsubw	%ymm2, %ymm13, %ymm14
+	vpsubw	%ymm7, %ymm13, %ymm14
 	vpsubw	%ymm10, %ymm3, %ymm9
 	vpsubw	%ymm4, %ymm6, %ymm12
-	vpaddw	%ymm13, %ymm2, %ymm2
+	vpaddw	%ymm13, %ymm7, %ymm2
 	vpaddw	%ymm3, %ymm10, %ymm3
 	vpmullw	%ymm14, %ymm1, %ymm11
 	vpaddw	%ymm6, %ymm4, %ymm6
@@ -14077,9 +14068,9 @@ L_poly_frommont$1:
 	vpmulhw	%ymm0, %ymm3, %ymm3
 	vpsubw	%ymm3, %ymm4, %ymm5
 	vmovdqu	%ymm5, 416(%rax)
-	vmovdqu	448(%rax), %ymm5
-	vpmulhw	%ymm2, %ymm5, %ymm4
-	vpmullw	%ymm2, %ymm5, %ymm3
+	vmovdqu	448(%rax), %ymm3
+	vpmulhw	%ymm2, %ymm3, %ymm4
+	vpmullw	%ymm2, %ymm3, %ymm3
 	vpmullw	%ymm1, %ymm3, %ymm3
 	vpmulhw	%ymm0, %ymm3, %ymm3
 	vpsubw	%ymm3, %ymm4, %ymm5
@@ -14174,19 +14165,19 @@ L_i_poly_frombytes$1:
 	vmovdqu	352(%r9), %ymm7
 	vperm2i128	$32, %ymm1, %ymm2, %ymm8
 	vperm2i128	$49, %ymm1, %ymm2, %ymm6
-	vperm2i128	$32, %ymm5, %ymm3, %ymm9
-	vperm2i128	$49, %ymm5, %ymm3, %ymm1
+	vperm2i128	$32, %ymm5, %ymm3, %ymm1
+	vperm2i128	$49, %ymm5, %ymm3, %ymm2
 	vperm2i128	$32, %ymm7, %ymm4, %ymm5
 	vperm2i128	$49, %ymm7, %ymm4, %ymm7
-	vpunpcklqdq	%ymm1, %ymm8, %ymm10
-	vpunpckhqdq	%ymm1, %ymm8, %ymm2
+	vpunpcklqdq	%ymm2, %ymm8, %ymm9
+	vpunpckhqdq	%ymm2, %ymm8, %ymm2
 	vpunpcklqdq	%ymm5, %ymm6, %ymm3
 	vpunpckhqdq	%ymm5, %ymm6, %ymm5
-	vpunpcklqdq	%ymm7, %ymm9, %ymm6
-	vpunpckhqdq	%ymm7, %ymm9, %ymm1
+	vpunpcklqdq	%ymm7, %ymm1, %ymm6
+	vpunpckhqdq	%ymm7, %ymm1, %ymm1
 	vmovsldup	%ymm5, %ymm11
-	vpblendd	$170, %ymm11, %ymm10, %ymm4
-	vpsrlq	$32, %ymm10, %ymm7
+	vpblendd	$170, %ymm11, %ymm9, %ymm4
+	vpsrlq	$32, %ymm9, %ymm7
 	vpblendd	$170, %ymm5, %ymm7, %ymm5
 	vmovsldup	%ymm6, %ymm11
 	vpblendd	$170, %ymm11, %ymm2, %ymm7
@@ -14639,9 +14630,9 @@ L_poly_basemul$1:
 	vpsubw	%ymm5, %ymm7, %ymm5
 	vpmullw	%ymm1, %ymm8, %ymm6
 	vpmulhw	%ymm0, %ymm6, %ymm0
-	vpsubw	%ymm0, %ymm4, %ymm0
+	vpsubw	%ymm0, %ymm4, %ymm4
 	vmovdqu	%ymm5, 448(%rcx)
-	vmovdqu	%ymm0, 480(%rcx)
+	vmovdqu	%ymm4, 480(%rcx)
 	ret
 L_poly_csubq$1:
 	vmovdqu	glob_data + 1184(%rip), %ymm0
@@ -14817,8 +14808,8 @@ L_shake256_A32__A1600$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
@@ -14859,8 +14850,8 @@ L_shake256_A32__A1600$9:
 	movq	$0, %rdx
 	jmp 	L_shake256_A32__A1600$6
 L_shake256_A32__A1600$7:
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -14902,8 +14893,8 @@ L_shake256_A32__A1600$8:
 L_shake256_A32__A1600$6:
 	cmpq	$10, %rdx
 	jb  	L_shake256_A32__A1600$7
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
@@ -14982,8 +14973,8 @@ L_shake256_A32__A1600$3:
 	call	L_keccakf1600_avx2$1
 L_shake256_A32__A1600$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm7
-	vmovdqu	%xmm7, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm4
+	vmovdqu	%xmm4, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -14996,8 +14987,8 @@ L_sha3_256A_A1568$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15038,8 +15029,8 @@ L_sha3_256A_A1568$9:
 	movq	$0, %rax
 	jmp 	L_sha3_256A_A1568$6
 L_sha3_256A_A1568$7:
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15081,8 +15072,8 @@ L_sha3_256A_A1568$8:
 L_sha3_256A_A1568$6:
 	cmpq	$10, %rax
 	jb  	L_sha3_256A_A1568$7
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15161,8 +15152,8 @@ L_sha3_256A_A1568$3:
 	call	L_keccakf1600_avx2$1
 L_sha3_256A_A1568$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm7
-	vmovdqu	%xmm7, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm4
+	vmovdqu	%xmm4, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -15380,8 +15371,8 @@ L_shake128x4_absorb_A32_A2$2:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %r9
 	shlq	$63, %r9
-	vmovq	%r9, %xmm7
-	vpbroadcastq	%xmm7, %ymm8
+	vmovq	%r9, %xmm4
+	vpbroadcastq	%xmm4, %ymm8
 	vpxor	640(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 640(%r8)
 	ret
@@ -15451,8 +15442,8 @@ L_shake256x4_A128__A32_A1$7:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %rcx
 	shlq	$63, %rcx
-	vmovq	%rcx, %xmm7
-	vpbroadcastq	%xmm7, %ymm8
+	vmovq	%rcx, %xmm4
+	vpbroadcastq	%xmm4, %ymm8
 	vpxor	512(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 512(%r8)
 	movq	$0, %rcx
@@ -15597,8 +15588,8 @@ L_sha3_512A_A64$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
@@ -15686,8 +15677,8 @@ L_sha3_512A_A33$1:
 	vpxor	%ymm1, %ymm1, %ymm1
 	vpxor	%ymm6, %ymm6, %ymm6
 	movq	$0, %rcx
-	vpbroadcastq	(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm4, %ymm4
+	vpbroadcastq	(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %xmm9
 	movq	24(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm10
@@ -16213,9 +16204,9 @@ L_nttunpack$1:
 	vpsrlq	$32, %ymm11, %ymm9
 	vpblendd	$170, %ymm5, %ymm9, %ymm5
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm4, %ymm9
-	vpsrld	$16, %ymm4, %ymm10
-	vpblendw	$170, %ymm1, %ymm10, %ymm0
+	vpblendw	$170, %ymm11, %ymm4, %ymm0
+	vpsrld	$16, %ymm4, %ymm9
+	vpblendw	$170, %ymm1, %ymm9, %ymm9
 	vpslld	$16, %ymm6, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
 	vpsrld	$16, %ymm2, %ymm10
@@ -16228,76 +16219,76 @@ L_nttunpack$1:
 	vpblendw	$170, %ymm6, %ymm7, %ymm3
 	vpsrld	$16, %ymm7, %ymm7
 	vpblendw	$170, %ymm5, %ymm7, %ymm15
-	vmovdqu	%ymm9, (%rcx)
-	vmovdqu	%ymm0, 32(%rcx)
+	vmovdqu	%ymm0, (%rcx)
+	vmovdqu	%ymm9, 32(%rcx)
 	vmovdqu	%ymm1, 64(%rcx)
 	vmovdqu	%ymm13, 96(%rcx)
 	vmovdqu	%ymm2, 128(%rcx)
 	vmovdqu	%ymm4, 160(%rcx)
 	vmovdqu	%ymm3, 192(%rcx)
 	vmovdqu	%ymm15, 224(%rcx)
-	vmovdqu	256(%rcx), %ymm3
-	vmovdqu	288(%rcx), %ymm5
+	vmovdqu	256(%rcx), %ymm2
+	vmovdqu	288(%rcx), %ymm3
 	vmovdqu	320(%rcx), %ymm1
 	vmovdqu	352(%rcx), %ymm8
-	vmovdqu	384(%rcx), %ymm6
+	vmovdqu	384(%rcx), %ymm5
 	vmovdqu	416(%rcx), %ymm7
-	vmovdqu	448(%rcx), %ymm12
+	vmovdqu	448(%rcx), %ymm4
 	vmovdqu	480(%rcx), %ymm15
-	vperm2i128	$32, %ymm6, %ymm3, %ymm2
-	vperm2i128	$49, %ymm6, %ymm3, %ymm4
-	vperm2i128	$32, %ymm7, %ymm5, %ymm6
-	vperm2i128	$49, %ymm7, %ymm5, %ymm3
-	vperm2i128	$32, %ymm12, %ymm1, %ymm7
-	vperm2i128	$49, %ymm12, %ymm1, %ymm1
+	vperm2i128	$32, %ymm5, %ymm2, %ymm0
+	vperm2i128	$49, %ymm5, %ymm2, %ymm2
+	vperm2i128	$32, %ymm7, %ymm3, %ymm6
+	vperm2i128	$49, %ymm7, %ymm3, %ymm7
+	vperm2i128	$32, %ymm4, %ymm1, %ymm5
+	vperm2i128	$49, %ymm4, %ymm1, %ymm1
 	vperm2i128	$32, %ymm15, %ymm8, %ymm10
 	vperm2i128	$49, %ymm15, %ymm8, %ymm8
-	vpunpcklqdq	%ymm7, %ymm2, %ymm5
-	vpunpckhqdq	%ymm7, %ymm2, %ymm7
-	vpunpcklqdq	%ymm1, %ymm4, %ymm9
-	vpunpckhqdq	%ymm1, %ymm4, %ymm4
+	vpunpcklqdq	%ymm5, %ymm0, %ymm3
+	vpunpckhqdq	%ymm5, %ymm0, %ymm4
+	vpunpcklqdq	%ymm1, %ymm2, %ymm5
+	vpunpckhqdq	%ymm1, %ymm2, %ymm9
 	vpunpcklqdq	%ymm10, %ymm6, %ymm2
 	vpunpckhqdq	%ymm10, %ymm6, %ymm1
-	vpunpcklqdq	%ymm8, %ymm3, %ymm6
-	vpunpckhqdq	%ymm8, %ymm3, %ymm8
+	vpunpcklqdq	%ymm8, %ymm7, %ymm6
+	vpunpckhqdq	%ymm8, %ymm7, %ymm7
 	vmovsldup	%ymm2, %ymm11
-	vpblendd	$170, %ymm11, %ymm5, %ymm10
-	vpsrlq	$32, %ymm5, %ymm3
+	vpblendd	$170, %ymm11, %ymm3, %ymm10
+	vpsrlq	$32, %ymm3, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
 	vmovsldup	%ymm1, %ymm11
-	vpblendd	$170, %ymm11, %ymm7, %ymm3
-	vpsrlq	$32, %ymm7, %ymm5
-	vpblendd	$170, %ymm1, %ymm5, %ymm5
-	vmovsldup	%ymm6, %ymm11
-	vpblendd	$170, %ymm11, %ymm9, %ymm1
-	vpsrlq	$32, %ymm9, %ymm7
-	vpblendd	$170, %ymm6, %ymm7, %ymm6
-	vmovsldup	%ymm8, %ymm11
-	vpblendd	$170, %ymm11, %ymm4, %ymm7
+	vpblendd	$170, %ymm11, %ymm4, %ymm3
 	vpsrlq	$32, %ymm4, %ymm4
-	vpblendd	$170, %ymm8, %ymm4, %ymm8
+	vpblendd	$170, %ymm1, %ymm4, %ymm4
+	vmovsldup	%ymm6, %ymm11
+	vpblendd	$170, %ymm11, %ymm5, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm5
+	vmovsldup	%ymm7, %ymm6
+	vpblendd	$170, %ymm6, %ymm9, %ymm6
+	vpsrlq	$32, %ymm9, %ymm9
+	vpblendd	$170, %ymm7, %ymm9, %ymm7
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm10, %ymm9
-	vpsrld	$16, %ymm10, %ymm10
-	vpblendw	$170, %ymm1, %ymm10, %ymm0
-	vpslld	$16, %ymm6, %ymm11
+	vpblendw	$170, %ymm11, %ymm10, %ymm0
+	vpsrld	$16, %ymm10, %ymm8
+	vpblendw	$170, %ymm1, %ymm8, %ymm9
+	vpslld	$16, %ymm5, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
-	vpsrld	$16, %ymm2, %ymm10
-	vpblendw	$170, %ymm6, %ymm10, %ymm13
-	vpslld	$16, %ymm7, %ymm2
+	vpsrld	$16, %ymm2, %ymm8
+	vpblendw	$170, %ymm5, %ymm8, %ymm8
+	vpslld	$16, %ymm6, %ymm2
 	vpblendw	$170, %ymm2, %ymm3, %ymm2
 	vpsrld	$16, %ymm3, %ymm3
-	vpblendw	$170, %ymm7, %ymm3, %ymm4
-	vpslld	$16, %ymm8, %ymm6
-	vpblendw	$170, %ymm6, %ymm5, %ymm3
-	vpsrld	$16, %ymm5, %ymm7
-	vpblendw	$170, %ymm8, %ymm7, %ymm15
-	vmovdqu	%ymm9, 256(%rcx)
-	vmovdqu	%ymm0, 288(%rcx)
+	vpblendw	$170, %ymm6, %ymm3, %ymm10
+	vpslld	$16, %ymm7, %ymm6
+	vpblendw	$170, %ymm6, %ymm4, %ymm3
+	vpsrld	$16, %ymm4, %ymm14
+	vpblendw	$170, %ymm7, %ymm14, %ymm15
+	vmovdqu	%ymm0, 256(%rcx)
+	vmovdqu	%ymm9, 288(%rcx)
 	vmovdqu	%ymm1, 320(%rcx)
-	vmovdqu	%ymm13, 352(%rcx)
+	vmovdqu	%ymm8, 352(%rcx)
 	vmovdqu	%ymm2, 384(%rcx)
-	vmovdqu	%ymm4, 416(%rcx)
+	vmovdqu	%ymm10, 416(%rcx)
 	vmovdqu	%ymm3, 448(%rcx)
 	vmovdqu	%ymm15, 480(%rcx)
 	ret

--- a/code/jasmin/1024/avx2/jkem_pqcp.s
+++ b/code/jasmin/1024/avx2/jkem_pqcp.s
@@ -3486,398 +3486,104 @@ Ljade_kem_mlkem_mlkem1024_amd64_avx2_dec$2:
 	vpor	%ymm2, %ymm0, %ymm0
 	vptest	%ymm0, %ymm0
 	cmovne	%rdx, %rax
-	movq	(%rbx), %rcx
-	movq	%rcx, 3776(%rsp)
-	movq	8(%rbx), %rcx
-	movq	%rcx, 3784(%rsp)
-	movq	16(%rbx), %rcx
-	movq	%rcx, 3792(%rsp)
-	movq	24(%rbx), %rcx
-	movq	%rcx, 3800(%rsp)
-	movq	32(%rbx), %rcx
-	movq	%rcx, 3808(%rsp)
-	movq	40(%rbx), %rcx
-	movq	%rcx, 3816(%rsp)
-	movq	48(%rbx), %rcx
-	movq	%rcx, 3824(%rsp)
-	movq	56(%rbx), %rcx
-	movq	%rcx, 3832(%rsp)
-	movq	64(%rbx), %rcx
-	movq	%rcx, 3840(%rsp)
-	movq	72(%rbx), %rcx
-	movq	%rcx, 3848(%rsp)
-	movq	80(%rbx), %rcx
-	movq	%rcx, 3856(%rsp)
-	movq	88(%rbx), %rcx
-	movq	%rcx, 3864(%rsp)
-	movq	96(%rbx), %rcx
-	movq	%rcx, 3872(%rsp)
-	movq	104(%rbx), %rcx
-	movq	%rcx, 3880(%rsp)
-	movq	112(%rbx), %rcx
-	movq	%rcx, 3888(%rsp)
-	movq	120(%rbx), %rcx
-	movq	%rcx, 3896(%rsp)
-	movq	128(%rbx), %rcx
-	movq	%rcx, 3904(%rsp)
-	movq	136(%rbx), %rcx
-	movq	%rcx, 3912(%rsp)
-	movq	144(%rbx), %rcx
-	movq	%rcx, 3920(%rsp)
-	movq	152(%rbx), %rcx
-	movq	%rcx, 3928(%rsp)
-	movq	160(%rbx), %rcx
-	movq	%rcx, 3936(%rsp)
-	movq	168(%rbx), %rcx
-	movq	%rcx, 3944(%rsp)
-	movq	176(%rbx), %rcx
-	movq	%rcx, 3952(%rsp)
-	movq	184(%rbx), %rcx
-	movq	%rcx, 3960(%rsp)
-	movq	192(%rbx), %rcx
-	movq	%rcx, 3968(%rsp)
-	movq	200(%rbx), %rcx
-	movq	%rcx, 3976(%rsp)
-	movq	208(%rbx), %rcx
-	movq	%rcx, 3984(%rsp)
-	movq	216(%rbx), %rcx
-	movq	%rcx, 3992(%rsp)
-	movq	224(%rbx), %rcx
-	movq	%rcx, 4000(%rsp)
-	movq	232(%rbx), %rcx
-	movq	%rcx, 4008(%rsp)
-	movq	240(%rbx), %rcx
-	movq	%rcx, 4016(%rsp)
-	movq	248(%rbx), %rcx
-	movq	%rcx, 4024(%rsp)
-	movq	256(%rbx), %rcx
-	movq	%rcx, 4032(%rsp)
-	movq	264(%rbx), %rcx
-	movq	%rcx, 4040(%rsp)
-	movq	272(%rbx), %rcx
-	movq	%rcx, 4048(%rsp)
-	movq	280(%rbx), %rcx
-	movq	%rcx, 4056(%rsp)
-	movq	288(%rbx), %rcx
-	movq	%rcx, 4064(%rsp)
-	movq	296(%rbx), %rcx
-	movq	%rcx, 4072(%rsp)
-	movq	304(%rbx), %rcx
-	movq	%rcx, 4080(%rsp)
-	movq	312(%rbx), %rcx
-	movq	%rcx, 4088(%rsp)
-	movq	320(%rbx), %rcx
-	movq	%rcx, 4096(%rsp)
-	movq	328(%rbx), %rcx
-	movq	%rcx, 4104(%rsp)
-	movq	336(%rbx), %rcx
-	movq	%rcx, 4112(%rsp)
-	movq	344(%rbx), %rcx
-	movq	%rcx, 4120(%rsp)
-	movq	352(%rbx), %rcx
-	movq	%rcx, 4128(%rsp)
-	movq	360(%rbx), %rcx
-	movq	%rcx, 4136(%rsp)
-	movq	368(%rbx), %rcx
-	movq	%rcx, 4144(%rsp)
-	movq	376(%rbx), %rcx
-	movq	%rcx, 4152(%rsp)
-	movq	384(%rbx), %rcx
-	movq	%rcx, 4160(%rsp)
-	movq	392(%rbx), %rcx
-	movq	%rcx, 4168(%rsp)
-	movq	400(%rbx), %rcx
-	movq	%rcx, 4176(%rsp)
-	movq	408(%rbx), %rcx
-	movq	%rcx, 4184(%rsp)
-	movq	416(%rbx), %rcx
-	movq	%rcx, 4192(%rsp)
-	movq	424(%rbx), %rcx
-	movq	%rcx, 4200(%rsp)
-	movq	432(%rbx), %rcx
-	movq	%rcx, 4208(%rsp)
-	movq	440(%rbx), %rcx
-	movq	%rcx, 4216(%rsp)
-	movq	448(%rbx), %rcx
-	movq	%rcx, 4224(%rsp)
-	movq	456(%rbx), %rcx
-	movq	%rcx, 4232(%rsp)
-	movq	464(%rbx), %rcx
-	movq	%rcx, 4240(%rsp)
-	movq	472(%rbx), %rcx
-	movq	%rcx, 4248(%rsp)
-	movq	480(%rbx), %rcx
-	movq	%rcx, 4256(%rsp)
-	movq	488(%rbx), %rcx
-	movq	%rcx, 4264(%rsp)
-	movq	496(%rbx), %rcx
-	movq	%rcx, 4272(%rsp)
-	movq	504(%rbx), %rcx
-	movq	%rcx, 4280(%rsp)
-	movq	512(%rbx), %rcx
-	movq	%rcx, 4288(%rsp)
-	movq	520(%rbx), %rcx
-	movq	%rcx, 4296(%rsp)
-	movq	528(%rbx), %rcx
-	movq	%rcx, 4304(%rsp)
-	movq	536(%rbx), %rcx
-	movq	%rcx, 4312(%rsp)
-	movq	544(%rbx), %rcx
-	movq	%rcx, 4320(%rsp)
-	movq	552(%rbx), %rcx
-	movq	%rcx, 4328(%rsp)
-	movq	560(%rbx), %rcx
-	movq	%rcx, 4336(%rsp)
-	movq	568(%rbx), %rcx
-	movq	%rcx, 4344(%rsp)
-	movq	576(%rbx), %rcx
-	movq	%rcx, 4352(%rsp)
-	movq	584(%rbx), %rcx
-	movq	%rcx, 4360(%rsp)
-	movq	592(%rbx), %rcx
-	movq	%rcx, 4368(%rsp)
-	movq	600(%rbx), %rcx
-	movq	%rcx, 4376(%rsp)
-	movq	608(%rbx), %rcx
-	movq	%rcx, 4384(%rsp)
-	movq	616(%rbx), %rcx
-	movq	%rcx, 4392(%rsp)
-	movq	624(%rbx), %rcx
-	movq	%rcx, 4400(%rsp)
-	movq	632(%rbx), %rcx
-	movq	%rcx, 4408(%rsp)
-	movq	640(%rbx), %rcx
-	movq	%rcx, 4416(%rsp)
-	movq	648(%rbx), %rcx
-	movq	%rcx, 4424(%rsp)
-	movq	656(%rbx), %rcx
-	movq	%rcx, 4432(%rsp)
-	movq	664(%rbx), %rcx
-	movq	%rcx, 4440(%rsp)
-	movq	672(%rbx), %rcx
-	movq	%rcx, 4448(%rsp)
-	movq	680(%rbx), %rcx
-	movq	%rcx, 4456(%rsp)
-	movq	688(%rbx), %rcx
-	movq	%rcx, 4464(%rsp)
-	movq	696(%rbx), %rcx
-	movq	%rcx, 4472(%rsp)
-	movq	704(%rbx), %rcx
-	movq	%rcx, 4480(%rsp)
-	movq	712(%rbx), %rcx
-	movq	%rcx, 4488(%rsp)
-	movq	720(%rbx), %rcx
-	movq	%rcx, 4496(%rsp)
-	movq	728(%rbx), %rcx
-	movq	%rcx, 4504(%rsp)
-	movq	736(%rbx), %rcx
-	movq	%rcx, 4512(%rsp)
-	movq	744(%rbx), %rcx
-	movq	%rcx, 4520(%rsp)
-	movq	752(%rbx), %rcx
-	movq	%rcx, 4528(%rsp)
-	movq	760(%rbx), %rcx
-	movq	%rcx, 4536(%rsp)
-	movq	768(%rbx), %rcx
-	movq	%rcx, 4544(%rsp)
-	movq	776(%rbx), %rcx
-	movq	%rcx, 4552(%rsp)
-	movq	784(%rbx), %rcx
-	movq	%rcx, 4560(%rsp)
-	movq	792(%rbx), %rcx
-	movq	%rcx, 4568(%rsp)
-	movq	800(%rbx), %rcx
-	movq	%rcx, 4576(%rsp)
-	movq	808(%rbx), %rcx
-	movq	%rcx, 4584(%rsp)
-	movq	816(%rbx), %rcx
-	movq	%rcx, 4592(%rsp)
-	movq	824(%rbx), %rcx
-	movq	%rcx, 4600(%rsp)
-	movq	832(%rbx), %rcx
-	movq	%rcx, 4608(%rsp)
-	movq	840(%rbx), %rcx
-	movq	%rcx, 4616(%rsp)
-	movq	848(%rbx), %rcx
-	movq	%rcx, 4624(%rsp)
-	movq	856(%rbx), %rcx
-	movq	%rcx, 4632(%rsp)
-	movq	864(%rbx), %rcx
-	movq	%rcx, 4640(%rsp)
-	movq	872(%rbx), %rcx
-	movq	%rcx, 4648(%rsp)
-	movq	880(%rbx), %rcx
-	movq	%rcx, 4656(%rsp)
-	movq	888(%rbx), %rcx
-	movq	%rcx, 4664(%rsp)
-	movq	896(%rbx), %rcx
-	movq	%rcx, 4672(%rsp)
-	movq	904(%rbx), %rcx
-	movq	%rcx, 4680(%rsp)
-	movq	912(%rbx), %rcx
-	movq	%rcx, 4688(%rsp)
-	movq	920(%rbx), %rcx
-	movq	%rcx, 4696(%rsp)
-	movq	928(%rbx), %rcx
-	movq	%rcx, 4704(%rsp)
-	movq	936(%rbx), %rcx
-	movq	%rcx, 4712(%rsp)
-	movq	944(%rbx), %rcx
-	movq	%rcx, 4720(%rsp)
-	movq	952(%rbx), %rcx
-	movq	%rcx, 4728(%rsp)
-	movq	960(%rbx), %rcx
-	movq	%rcx, 4736(%rsp)
-	movq	968(%rbx), %rcx
-	movq	%rcx, 4744(%rsp)
-	movq	976(%rbx), %rcx
-	movq	%rcx, 4752(%rsp)
-	movq	984(%rbx), %rcx
-	movq	%rcx, 4760(%rsp)
-	movq	992(%rbx), %rcx
-	movq	%rcx, 4768(%rsp)
-	movq	1000(%rbx), %rcx
-	movq	%rcx, 4776(%rsp)
-	movq	1008(%rbx), %rcx
-	movq	%rcx, 4784(%rsp)
-	movq	1016(%rbx), %rcx
-	movq	%rcx, 4792(%rsp)
-	movq	1024(%rbx), %rcx
-	movq	%rcx, 4800(%rsp)
-	movq	1032(%rbx), %rcx
-	movq	%rcx, 4808(%rsp)
-	movq	1040(%rbx), %rcx
-	movq	%rcx, 4816(%rsp)
-	movq	1048(%rbx), %rcx
-	movq	%rcx, 4824(%rsp)
-	movq	1056(%rbx), %rcx
-	movq	%rcx, 4832(%rsp)
-	movq	1064(%rbx), %rcx
-	movq	%rcx, 4840(%rsp)
-	movq	1072(%rbx), %rcx
-	movq	%rcx, 4848(%rsp)
-	movq	1080(%rbx), %rcx
-	movq	%rcx, 4856(%rsp)
-	movq	1088(%rbx), %rcx
-	movq	%rcx, 4864(%rsp)
-	movq	1096(%rbx), %rcx
-	movq	%rcx, 4872(%rsp)
-	movq	1104(%rbx), %rcx
-	movq	%rcx, 4880(%rsp)
-	movq	1112(%rbx), %rcx
-	movq	%rcx, 4888(%rsp)
-	movq	1120(%rbx), %rcx
-	movq	%rcx, 4896(%rsp)
-	movq	1128(%rbx), %rcx
-	movq	%rcx, 4904(%rsp)
-	movq	1136(%rbx), %rcx
-	movq	%rcx, 4912(%rsp)
-	movq	1144(%rbx), %rcx
-	movq	%rcx, 4920(%rsp)
-	movq	1152(%rbx), %rcx
-	movq	%rcx, 4928(%rsp)
-	movq	1160(%rbx), %rcx
-	movq	%rcx, 4936(%rsp)
-	movq	1168(%rbx), %rcx
-	movq	%rcx, 4944(%rsp)
-	movq	1176(%rbx), %rcx
-	movq	%rcx, 4952(%rsp)
-	movq	1184(%rbx), %rcx
-	movq	%rcx, 4960(%rsp)
-	movq	1192(%rbx), %rcx
-	movq	%rcx, 4968(%rsp)
-	movq	1200(%rbx), %rcx
-	movq	%rcx, 4976(%rsp)
-	movq	1208(%rbx), %rcx
-	movq	%rcx, 4984(%rsp)
-	movq	1216(%rbx), %rcx
-	movq	%rcx, 4992(%rsp)
-	movq	1224(%rbx), %rcx
-	movq	%rcx, 5000(%rsp)
-	movq	1232(%rbx), %rcx
-	movq	%rcx, 5008(%rsp)
-	movq	1240(%rbx), %rcx
-	movq	%rcx, 5016(%rsp)
-	movq	1248(%rbx), %rcx
-	movq	%rcx, 5024(%rsp)
-	movq	1256(%rbx), %rcx
-	movq	%rcx, 5032(%rsp)
-	movq	1264(%rbx), %rcx
-	movq	%rcx, 5040(%rsp)
-	movq	1272(%rbx), %rcx
-	movq	%rcx, 5048(%rsp)
-	movq	1280(%rbx), %rcx
-	movq	%rcx, 5056(%rsp)
-	movq	1288(%rbx), %rcx
-	movq	%rcx, 5064(%rsp)
-	movq	1296(%rbx), %rcx
-	movq	%rcx, 5072(%rsp)
-	movq	1304(%rbx), %rcx
-	movq	%rcx, 5080(%rsp)
-	movq	1312(%rbx), %rcx
-	movq	%rcx, 5088(%rsp)
-	movq	1320(%rbx), %rcx
-	movq	%rcx, 5096(%rsp)
-	movq	1328(%rbx), %rcx
-	movq	%rcx, 5104(%rsp)
-	movq	1336(%rbx), %rcx
-	movq	%rcx, 5112(%rsp)
-	movq	1344(%rbx), %rcx
-	movq	%rcx, 5120(%rsp)
-	movq	1352(%rbx), %rcx
-	movq	%rcx, 5128(%rsp)
-	movq	1360(%rbx), %rcx
-	movq	%rcx, 5136(%rsp)
-	movq	1368(%rbx), %rcx
-	movq	%rcx, 5144(%rsp)
-	movq	1376(%rbx), %rcx
-	movq	%rcx, 5152(%rsp)
-	movq	1384(%rbx), %rcx
-	movq	%rcx, 5160(%rsp)
-	movq	1392(%rbx), %rcx
-	movq	%rcx, 5168(%rsp)
-	movq	1400(%rbx), %rcx
-	movq	%rcx, 5176(%rsp)
-	movq	1408(%rbx), %rcx
-	movq	%rcx, 5184(%rsp)
-	movq	1416(%rbx), %rcx
-	movq	%rcx, 5192(%rsp)
-	movq	1424(%rbx), %rcx
-	movq	%rcx, 5200(%rsp)
-	movq	1432(%rbx), %rcx
-	movq	%rcx, 5208(%rsp)
-	movq	1440(%rbx), %rcx
-	movq	%rcx, 5216(%rsp)
-	movq	1448(%rbx), %rcx
-	movq	%rcx, 5224(%rsp)
-	movq	1456(%rbx), %rcx
-	movq	%rcx, 5232(%rsp)
-	movq	1464(%rbx), %rcx
-	movq	%rcx, 5240(%rsp)
-	movq	1472(%rbx), %rcx
-	movq	%rcx, 5248(%rsp)
-	movq	1480(%rbx), %rcx
-	movq	%rcx, 5256(%rsp)
-	movq	1488(%rbx), %rcx
-	movq	%rcx, 5264(%rsp)
-	movq	1496(%rbx), %rcx
-	movq	%rcx, 5272(%rsp)
-	movq	1504(%rbx), %rcx
-	movq	%rcx, 5280(%rsp)
-	movq	1512(%rbx), %rcx
-	movq	%rcx, 5288(%rsp)
-	movq	1520(%rbx), %rcx
-	movq	%rcx, 5296(%rsp)
-	movq	1528(%rbx), %rcx
-	movq	%rcx, 5304(%rsp)
-	movq	1536(%rbx), %rcx
-	movq	%rcx, 5312(%rsp)
-	movq	1544(%rbx), %rcx
-	movq	%rcx, 5320(%rsp)
-	movq	1552(%rbx), %rcx
-	movq	%rcx, 5328(%rsp)
-	movq	1560(%rbx), %rcx
-	movq	%rcx, 5336(%rsp)
+	vmovdqu	(%rbx), %ymm0
+	vmovdqu	%ymm0, 3776(%rsp)
+	vmovdqu	32(%rbx), %ymm0
+	vmovdqu	%ymm0, 3808(%rsp)
+	vmovdqu	64(%rbx), %ymm0
+	vmovdqu	%ymm0, 3840(%rsp)
+	vmovdqu	96(%rbx), %ymm0
+	vmovdqu	%ymm0, 3872(%rsp)
+	vmovdqu	128(%rbx), %ymm0
+	vmovdqu	%ymm0, 3904(%rsp)
+	vmovdqu	160(%rbx), %ymm0
+	vmovdqu	%ymm0, 3936(%rsp)
+	vmovdqu	192(%rbx), %ymm0
+	vmovdqu	%ymm0, 3968(%rsp)
+	vmovdqu	224(%rbx), %ymm0
+	vmovdqu	%ymm0, 4000(%rsp)
+	vmovdqu	256(%rbx), %ymm0
+	vmovdqu	%ymm0, 4032(%rsp)
+	vmovdqu	288(%rbx), %ymm0
+	vmovdqu	%ymm0, 4064(%rsp)
+	vmovdqu	320(%rbx), %ymm0
+	vmovdqu	%ymm0, 4096(%rsp)
+	vmovdqu	352(%rbx), %ymm0
+	vmovdqu	%ymm0, 4128(%rsp)
+	vmovdqu	384(%rbx), %ymm0
+	vmovdqu	%ymm0, 4160(%rsp)
+	vmovdqu	416(%rbx), %ymm0
+	vmovdqu	%ymm0, 4192(%rsp)
+	vmovdqu	448(%rbx), %ymm0
+	vmovdqu	%ymm0, 4224(%rsp)
+	vmovdqu	480(%rbx), %ymm0
+	vmovdqu	%ymm0, 4256(%rsp)
+	vmovdqu	512(%rbx), %ymm0
+	vmovdqu	%ymm0, 4288(%rsp)
+	vmovdqu	544(%rbx), %ymm0
+	vmovdqu	%ymm0, 4320(%rsp)
+	vmovdqu	576(%rbx), %ymm0
+	vmovdqu	%ymm0, 4352(%rsp)
+	vmovdqu	608(%rbx), %ymm0
+	vmovdqu	%ymm0, 4384(%rsp)
+	vmovdqu	640(%rbx), %ymm0
+	vmovdqu	%ymm0, 4416(%rsp)
+	vmovdqu	672(%rbx), %ymm0
+	vmovdqu	%ymm0, 4448(%rsp)
+	vmovdqu	704(%rbx), %ymm0
+	vmovdqu	%ymm0, 4480(%rsp)
+	vmovdqu	736(%rbx), %ymm0
+	vmovdqu	%ymm0, 4512(%rsp)
+	vmovdqu	768(%rbx), %ymm0
+	vmovdqu	%ymm0, 4544(%rsp)
+	vmovdqu	800(%rbx), %ymm0
+	vmovdqu	%ymm0, 4576(%rsp)
+	vmovdqu	832(%rbx), %ymm0
+	vmovdqu	%ymm0, 4608(%rsp)
+	vmovdqu	864(%rbx), %ymm0
+	vmovdqu	%ymm0, 4640(%rsp)
+	vmovdqu	896(%rbx), %ymm0
+	vmovdqu	%ymm0, 4672(%rsp)
+	vmovdqu	928(%rbx), %ymm0
+	vmovdqu	%ymm0, 4704(%rsp)
+	vmovdqu	960(%rbx), %ymm0
+	vmovdqu	%ymm0, 4736(%rsp)
+	vmovdqu	992(%rbx), %ymm0
+	vmovdqu	%ymm0, 4768(%rsp)
+	vmovdqu	1024(%rbx), %ymm0
+	vmovdqu	%ymm0, 4800(%rsp)
+	vmovdqu	1056(%rbx), %ymm0
+	vmovdqu	%ymm0, 4832(%rsp)
+	vmovdqu	1088(%rbx), %ymm0
+	vmovdqu	%ymm0, 4864(%rsp)
+	vmovdqu	1120(%rbx), %ymm0
+	vmovdqu	%ymm0, 4896(%rsp)
+	vmovdqu	1152(%rbx), %ymm0
+	vmovdqu	%ymm0, 4928(%rsp)
+	vmovdqu	1184(%rbx), %ymm0
+	vmovdqu	%ymm0, 4960(%rsp)
+	vmovdqu	1216(%rbx), %ymm0
+	vmovdqu	%ymm0, 4992(%rsp)
+	vmovdqu	1248(%rbx), %ymm0
+	vmovdqu	%ymm0, 5024(%rsp)
+	vmovdqu	1280(%rbx), %ymm0
+	vmovdqu	%ymm0, 5056(%rsp)
+	vmovdqu	1312(%rbx), %ymm0
+	vmovdqu	%ymm0, 5088(%rsp)
+	vmovdqu	1344(%rbx), %ymm0
+	vmovdqu	%ymm0, 5120(%rsp)
+	vmovdqu	1376(%rbx), %ymm0
+	vmovdqu	%ymm0, 5152(%rsp)
+	vmovdqu	1408(%rbx), %ymm0
+	vmovdqu	%ymm0, 5184(%rsp)
+	vmovdqu	1440(%rbx), %ymm0
+	vmovdqu	%ymm0, 5216(%rsp)
+	vmovdqu	1472(%rbx), %ymm0
+	vmovdqu	%ymm0, 5248(%rsp)
+	vmovdqu	1504(%rbx), %ymm0
+	vmovdqu	%ymm0, 5280(%rsp)
+	vmovdqu	1536(%rbx), %ymm0
+	vmovdqu	%ymm0, 5312(%rsp)
 	movq	%mm1, %rsi
 	leaq	3744(%rsp), %rbp
 	call	L_shake256_A32__A1600$1
@@ -11355,12 +11061,12 @@ L_gen_matrix_buf_rejection$14:
 	cmovnbe	%r12, %r11
 	vmovdqu	%xmm4, (%r9,%rbp,2)
 L_gen_matrix_buf_rejection$15:
-	vextracti128	$1, %ymm3, %xmm3
+	vextracti128	$1, %ymm3, %xmm4
 	cmpq	$248, %r13
 	jbe 	L_gen_matrix_buf_rejection$6
 	movq	$-1, %rbp
 	cmovbe	%rbp, %r11
-	movq	%xmm3, %r12
+	movq	%xmm4, %r12
 	cmpq	$252, %r13
 	jbe 	L_gen_matrix_buf_rejection$12
 	movq	$-1, %rbp
@@ -11370,7 +11076,7 @@ L_gen_matrix_buf_rejection$12:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
 	movq	%r12, (%r9,%r13,2)
-	vpextrq	$1, %xmm3, %r12
+	vpextrq	$1, %xmm4, %r12
 	addq	$4, %r13
 L_gen_matrix_buf_rejection$13:
 	cmpq	$254, %r13
@@ -11399,7 +11105,7 @@ L_gen_matrix_buf_rejection$9:
 L_gen_matrix_buf_rejection$6:
 	movq	$-1, %rbp
 	cmovnbe	%rbp, %r11
-	vmovdqu	%xmm3, (%r9,%r13,2)
+	vmovdqu	%xmm4, (%r9,%r13,2)
 L_gen_matrix_buf_rejection$7:
 	movq	%r14, %rbp
 	movq	8(%rsp), %r13
@@ -11742,27 +11448,27 @@ L_i_poly_tobytes$2:
 	vmovsldup	%ymm3, %ymm6
 	vpblendd	$170, %ymm6, %ymm9, %ymm6
 	vpsrlq	$32, %ymm9, %ymm7
-	vpblendd	$170, %ymm3, %ymm7, %ymm3
-	vmovsldup	%ymm1, %ymm11
-	vpblendd	$170, %ymm11, %ymm4, %ymm7
+	vpblendd	$170, %ymm3, %ymm7, %ymm11
+	vmovsldup	%ymm1, %ymm15
+	vpblendd	$170, %ymm15, %ymm4, %ymm3
 	vpsrlq	$32, %ymm4, %ymm4
 	vpblendd	$170, %ymm1, %ymm4, %ymm1
 	vpunpcklqdq	%ymm6, %ymm2, %ymm4
 	vpunpckhqdq	%ymm6, %ymm2, %ymm0
-	vpunpcklqdq	%ymm5, %ymm7, %ymm6
-	vpunpckhqdq	%ymm5, %ymm7, %ymm2
-	vpunpcklqdq	%ymm1, %ymm3, %ymm8
-	vpunpckhqdq	%ymm1, %ymm3, %ymm1
-	vperm2i128	$32, %ymm6, %ymm4, %ymm11
-	vperm2i128	$49, %ymm6, %ymm4, %ymm6
-	vperm2i128	$32, %ymm0, %ymm8, %ymm4
-	vperm2i128	$49, %ymm0, %ymm8, %ymm0
-	vperm2i128	$32, %ymm1, %ymm2, %ymm3
-	vperm2i128	$49, %ymm1, %ymm2, %ymm1
+	vpunpcklqdq	%ymm5, %ymm3, %ymm2
+	vpunpckhqdq	%ymm5, %ymm3, %ymm6
+	vpunpcklqdq	%ymm1, %ymm11, %ymm3
+	vpunpckhqdq	%ymm1, %ymm11, %ymm1
+	vperm2i128	$32, %ymm2, %ymm4, %ymm11
+	vperm2i128	$49, %ymm2, %ymm4, %ymm10
+	vperm2i128	$32, %ymm0, %ymm3, %ymm2
+	vperm2i128	$49, %ymm0, %ymm3, %ymm0
+	vperm2i128	$32, %ymm1, %ymm6, %ymm3
+	vperm2i128	$49, %ymm1, %ymm6, %ymm1
 	vmovdqu	%ymm11, (%rsi)
-	vmovdqu	%ymm4, 32(%rsi)
+	vmovdqu	%ymm2, 32(%rsi)
 	vmovdqu	%ymm3, 64(%rsi)
-	vmovdqu	%ymm6, 96(%rsi)
+	vmovdqu	%ymm10, 96(%rsi)
 	vmovdqu	%ymm0, 128(%rsi)
 	vmovdqu	%ymm1, 160(%rsi)
 	vmovdqu	256(%rcx), %ymm6
@@ -11816,21 +11522,21 @@ L_i_poly_tobytes$2:
 	vpunpcklqdq	%ymm6, %ymm2, %ymm4
 	vpunpckhqdq	%ymm6, %ymm2, %ymm2
 	vpunpcklqdq	%ymm5, %ymm7, %ymm6
-	vpunpckhqdq	%ymm5, %ymm7, %ymm5
-	vpunpcklqdq	%ymm1, %ymm3, %ymm7
+	vpunpckhqdq	%ymm5, %ymm7, %ymm0
+	vpunpcklqdq	%ymm1, %ymm3, %ymm5
 	vpunpckhqdq	%ymm1, %ymm3, %ymm1
 	vperm2i128	$32, %ymm6, %ymm4, %ymm11
 	vperm2i128	$49, %ymm6, %ymm4, %ymm6
-	vperm2i128	$32, %ymm2, %ymm7, %ymm4
-	vperm2i128	$49, %ymm2, %ymm7, %ymm0
-	vperm2i128	$32, %ymm1, %ymm5, %ymm3
-	vperm2i128	$49, %ymm1, %ymm5, %ymm9
+	vperm2i128	$32, %ymm2, %ymm5, %ymm4
+	vperm2i128	$49, %ymm2, %ymm5, %ymm2
+	vperm2i128	$32, %ymm1, %ymm0, %ymm3
+	vperm2i128	$49, %ymm1, %ymm0, %ymm1
 	vmovdqu	%ymm11, 192(%rsi)
 	vmovdqu	%ymm4, 224(%rsi)
 	vmovdqu	%ymm3, 256(%rsi)
 	vmovdqu	%ymm6, 288(%rsi)
-	vmovdqu	%ymm0, 320(%rsi)
-	vmovdqu	%ymm9, 352(%rsi)
+	vmovdqu	%ymm2, 320(%rsi)
+	vmovdqu	%ymm1, 352(%rsi)
 	ret
 L_poly_sub$1:
 	vmovdqu	(%rsi), %ymm2
@@ -11936,7 +11642,7 @@ L_poly_ntt$1:
 	vpsubw	%ymm9, %ymm14, %ymm9
 	vpaddw	%ymm12, %ymm10, %ymm12
 	vpsubw	%ymm10, %ymm1, %ymm1
-	vpaddw	%ymm7, %ymm11, %ymm15
+	vpaddw	%ymm7, %ymm11, %ymm7
 	vpsubw	%ymm11, %ymm3, %ymm14
 	vmovdqu	%ymm6, (%rcx)
 	vmovdqu	%ymm9, 32(%rcx)
@@ -11945,7 +11651,7 @@ L_poly_ntt$1:
 	vmovdqu	%ymm5, 256(%rcx)
 	vmovdqu	%ymm8, 288(%rcx)
 	vmovdqu	%ymm12, 320(%rcx)
-	vmovdqu	%ymm15, 352(%rcx)
+	vmovdqu	%ymm7, 352(%rcx)
 	vmovdqu	128(%rcx), %ymm8
 	vmovdqu	160(%rcx), %ymm6
 	vmovdqu	192(%rcx), %ymm1
@@ -11975,26 +11681,28 @@ L_poly_ntt$1:
 	vpsubw	%ymm5, %ymm1, %ymm12
 	vpaddw	%ymm1, %ymm5, %ymm1
 	vpaddw	%ymm9, %ymm2, %ymm5
-	vpsubw	%ymm2, %ymm8, %ymm8
-	vpaddw	%ymm13, %ymm4, %ymm9
+	vpsubw	%ymm2, %ymm8, %ymm9
+	vpaddw	%ymm13, %ymm4, %ymm8
 	vpsubw	%ymm4, %ymm6, %ymm6
-	vpaddw	%ymm12, %ymm10, %ymm4
-	vpsubw	%ymm10, %ymm1, %ymm12
-	vpaddw	%ymm7, %ymm11, %ymm15
+	vpaddw	%ymm12, %ymm10, %ymm12
+	vpsubw	%ymm10, %ymm1, %ymm1
+	vpaddw	%ymm7, %ymm11, %ymm4
 	vpsubw	%ymm11, %ymm3, %ymm13
 	vmovdqu	%ymm5, 384(%rcx)
-	vmovdqu	%ymm9, 416(%rcx)
-	vmovdqu	%ymm4, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm8, 416(%rcx)
+	vmovdqu	%ymm12, 448(%rcx)
+	vmovdqu	%ymm4, 480(%rcx)
 	vpbroadcastd	glob_data + 2024(%rip), %ymm2
 	vpbroadcastd	glob_data + 2028(%rip), %ymm4
+	vmovdqu	%ymm9, %ymm11
 	vmovdqu	%ymm6, %ymm10
+	vmovdqu	%ymm1, %ymm12
 	vmovdqu	(%rcx), %ymm9
 	vmovdqu	32(%rcx), %ymm6
 	vmovdqu	64(%rcx), %ymm7
 	vmovdqu	96(%rcx), %ymm5
-	vpmullw	%ymm8, %ymm2, %ymm15
-	vpmulhw	%ymm8, %ymm4, %ymm3
+	vpmullw	%ymm11, %ymm2, %ymm15
+	vpmulhw	%ymm11, %ymm4, %ymm3
 	vpmullw	%ymm10, %ymm2, %ymm11
 	vpmulhw	%ymm10, %ymm4, %ymm10
 	vpmullw	%ymm12, %ymm2, %ymm1
@@ -12107,8 +11815,8 @@ L_poly_ntt$1:
 	vpblendd	$170, %ymm2, %ymm4, %ymm2
 	vpsrlq	$32, %ymm4, %ymm4
 	vpblendd	$170, %ymm8, %ymm4, %ymm8
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm11, %ymm15
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm11, %ymm15
 	vpsrlq	$32, %ymm11, %ymm4
 	vpblendd	$170, %ymm6, %ymm4, %ymm14
 	vmovsldup	%ymm1, %ymm6
@@ -12237,7 +11945,7 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm6, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
-	vpsubw	%ymm7, %ymm6, %ymm12
+	vpsubw	%ymm7, %ymm6, %ymm10
 	vpmulhw	%ymm5, %ymm11, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
@@ -12253,18 +11961,18 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm3, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm3, %ymm15
+	vpsubw	%ymm5, %ymm3, %ymm7
 	vmovdqu	%ymm2, (%rcx)
 	vmovdqu	%ymm4, 32(%rcx)
 	vmovdqu	%ymm6, 64(%rcx)
 	vmovdqu	%ymm8, 96(%rcx)
 	vmovdqu	%ymm1, 128(%rcx)
-	vmovdqu	%ymm12, 160(%rcx)
+	vmovdqu	%ymm10, 160(%rcx)
 	vmovdqu	%ymm13, 192(%rcx)
-	vmovdqu	%ymm15, 224(%rcx)
+	vmovdqu	%ymm7, 224(%rcx)
 	vpbroadcastd	glob_data + 2416(%rip), %ymm2
 	vpbroadcastd	glob_data + 2420(%rip), %ymm6
-	vmovdqu	384(%rcx), %ymm8
+	vmovdqu	384(%rcx), %ymm15
 	vmovdqu	416(%rcx), %ymm13
 	vmovdqu	448(%rcx), %ymm5
 	vmovdqu	480(%rcx), %ymm7
@@ -12272,8 +11980,8 @@ L_poly_ntt$1:
 	vmovdqu	288(%rcx), %ymm3
 	vmovdqu	320(%rcx), %ymm12
 	vmovdqu	352(%rcx), %ymm4
-	vpmullw	%ymm8, %ymm2, %ymm11
-	vpmulhw	%ymm8, %ymm6, %ymm10
+	vpmullw	%ymm15, %ymm2, %ymm11
+	vpmulhw	%ymm15, %ymm6, %ymm10
 	vpmullw	%ymm13, %ymm2, %ymm8
 	vpmulhw	%ymm13, %ymm6, %ymm15
 	vpmullw	%ymm5, %ymm2, %ymm1
@@ -12378,30 +12086,30 @@ L_poly_ntt$1:
 	vpsubw	%ymm2, %ymm5, %ymm2
 	vmovdqu	glob_data + 2552(%rip), %ymm3
 	vmovdqu	glob_data + 2584(%rip), %ymm5
-	vmovsldup	%ymm7, %ymm14
-	vpblendd	$170, %ymm14, %ymm10, %ymm9
+	vmovsldup	%ymm7, %ymm15
+	vpblendd	$170, %ymm15, %ymm10, %ymm9
 	vpsrlq	$32, %ymm10, %ymm10
 	vpblendd	$170, %ymm7, %ymm10, %ymm7
-	vmovsldup	%ymm8, %ymm14
-	vpblendd	$170, %ymm14, %ymm4, %ymm1
+	vmovsldup	%ymm8, %ymm15
+	vpblendd	$170, %ymm15, %ymm4, %ymm1
 	vpsrlq	$32, %ymm4, %ymm4
 	vpblendd	$170, %ymm8, %ymm4, %ymm8
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm11, %ymm4
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm11, %ymm4
 	vpsrlq	$32, %ymm11, %ymm10
 	vpblendd	$170, %ymm6, %ymm10, %ymm10
 	vmovsldup	%ymm13, %ymm6
-	vpblendd	$170, %ymm6, %ymm2, %ymm12
+	vpblendd	$170, %ymm6, %ymm2, %ymm15
 	vpsrlq	$32, %ymm2, %ymm2
-	vpblendd	$170, %ymm13, %ymm2, %ymm15
+	vpblendd	$170, %ymm13, %ymm2, %ymm12
 	vpmullw	%ymm4, %ymm3, %ymm6
 	vpmulhw	%ymm4, %ymm5, %ymm14
 	vpmullw	%ymm10, %ymm3, %ymm4
 	vpmulhw	%ymm10, %ymm5, %ymm10
-	vpmullw	%ymm12, %ymm3, %ymm11
-	vpmulhw	%ymm12, %ymm5, %ymm2
-	vpmullw	%ymm15, %ymm3, %ymm13
-	vpmulhw	%ymm15, %ymm5, %ymm12
+	vpmullw	%ymm15, %ymm3, %ymm11
+	vpmulhw	%ymm15, %ymm5, %ymm2
+	vpmullw	%ymm12, %ymm3, %ymm13
+	vpmulhw	%ymm12, %ymm5, %ymm12
 	vpmulhw	%ymm0, %ymm6, %ymm6
 	vpmulhw	%ymm0, %ymm4, %ymm4
 	vpmulhw	%ymm0, %ymm11, %ymm3
@@ -12516,7 +12224,7 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm6, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
-	vpsubw	%ymm7, %ymm6, %ymm12
+	vpsubw	%ymm7, %ymm6, %ymm10
 	vpmulhw	%ymm5, %ymm11, %ymm7
 	vpsraw	$10, %ymm7, %ymm7
 	vpmullw	%ymm0, %ymm7, %ymm7
@@ -12532,15 +12240,15 @@ L_poly_ntt$1:
 	vpmulhw	%ymm5, %ymm3, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm3, %ymm15
+	vpsubw	%ymm5, %ymm3, %ymm7
 	vmovdqu	%ymm2, 256(%rcx)
 	vmovdqu	%ymm4, 288(%rcx)
 	vmovdqu	%ymm6, 320(%rcx)
 	vmovdqu	%ymm8, 352(%rcx)
 	vmovdqu	%ymm1, 384(%rcx)
-	vmovdqu	%ymm12, 416(%rcx)
+	vmovdqu	%ymm10, 416(%rcx)
 	vmovdqu	%ymm13, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm7, 480(%rcx)
 	ret
 L_poly_invntt$1:
 	vmovdqu	glob_data + 1184(%rip), %ymm0
@@ -12673,8 +12381,8 @@ L_poly_invntt$1:
 	vpblendd	$170, %ymm11, %ymm7, %ymm9
 	vpsrlq	$32, %ymm7, %ymm7
 	vpblendd	$170, %ymm10, %ymm7, %ymm11
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm12, %ymm10
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm12, %ymm10
 	vpsrlq	$32, %ymm12, %ymm7
 	vpblendd	$170, %ymm6, %ymm7, %ymm14
 	vmovsldup	%ymm3, %ymm6
@@ -12786,19 +12494,19 @@ L_poly_invntt$1:
 	vpsubw	%ymm11, %ymm6, %ymm6
 	vpsubw	%ymm13, %ymm8, %ymm8
 	vpsubw	%ymm4, %ymm12, %ymm4
-	vpsubw	%ymm5, %ymm14, %ymm15
+	vpsubw	%ymm5, %ymm14, %ymm7
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm1
-	vmovdqu	%ymm1, (%rcx)
+	vpsubw	%ymm5, %ymm9, %ymm9
+	vmovdqu	%ymm9, (%rcx)
 	vmovdqu	%ymm10, 32(%rcx)
 	vmovdqu	%ymm2, 64(%rcx)
 	vmovdqu	%ymm3, 96(%rcx)
 	vmovdqu	%ymm6, 128(%rcx)
 	vmovdqu	%ymm8, 160(%rcx)
 	vmovdqu	%ymm4, 192(%rcx)
-	vmovdqu	%ymm15, 224(%rcx)
+	vmovdqu	%ymm7, 224(%rcx)
 	vmovdqu	glob_data + 1608(%rip), %ymm10
 	vmovdqu	glob_data + 1672(%rip), %ymm1
 	vmovdqu	glob_data + 1640(%rip), %ymm2
@@ -12827,11 +12535,11 @@ L_poly_invntt$1:
 	vpmulhw	%ymm7, %ymm2, %ymm7
 	vpmulhw	%ymm8, %ymm5, %ymm2
 	vpmulhw	%ymm10, %ymm5, %ymm10
-	vpmulhw	%ymm9, %ymm0, %ymm8
+	vpmulhw	%ymm9, %ymm0, %ymm9
 	vpmulhw	%ymm13, %ymm0, %ymm13
 	vpmulhw	%ymm12, %ymm0, %ymm5
 	vpmulhw	%ymm1, %ymm0, %ymm1
-	vpsubw	%ymm8, %ymm15, %ymm12
+	vpsubw	%ymm9, %ymm15, %ymm12
 	vpsubw	%ymm13, %ymm7, %ymm8
 	vpsubw	%ymm5, %ymm2, %ymm9
 	vpsubw	%ymm1, %ymm10, %ymm7
@@ -13041,36 +12749,38 @@ L_poly_invntt$1:
 	vpsubw	%ymm11, %ymm6, %ymm6
 	vpsubw	%ymm13, %ymm8, %ymm8
 	vpsubw	%ymm4, %ymm12, %ymm4
-	vpsubw	%ymm5, %ymm14, %ymm15
+	vpsubw	%ymm5, %ymm14, %ymm7
 	vpmulhw	%ymm1, %ymm9, %ymm5
 	vpsraw	$10, %ymm5, %ymm5
 	vpmullw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm9, %ymm7
+	vpsubw	%ymm5, %ymm9, %ymm9
 	vmovdqu	%ymm6, 384(%rcx)
 	vmovdqu	%ymm8, 416(%rcx)
 	vmovdqu	%ymm4, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm7, 480(%rcx)
 	vpbroadcastd	glob_data + 2000(%rip), %ymm1
 	vpbroadcastd	glob_data + 2004(%rip), %ymm5
-	vmovdqu	%ymm3, %ymm15
-	vmovdqu	%ymm2, %ymm4
-	vmovdqu	(%rcx), %ymm13
-	vmovdqu	32(%rcx), %ymm3
-	vmovdqu	64(%rcx), %ymm6
+	vmovdqu	%ymm3, %ymm4
+	vmovdqu	%ymm2, %ymm6
+	vmovdqu	%ymm10, %ymm3
+	vmovdqu	%ymm9, %ymm2
+	vmovdqu	(%rcx), %ymm7
+	vmovdqu	32(%rcx), %ymm11
+	vmovdqu	64(%rcx), %ymm10
 	vmovdqu	96(%rcx), %ymm8
-	vpsubw	%ymm7, %ymm13, %ymm14
-	vpsubw	%ymm10, %ymm3, %ymm9
-	vpsubw	%ymm4, %ymm6, %ymm12
-	vpaddw	%ymm13, %ymm7, %ymm2
-	vpaddw	%ymm3, %ymm10, %ymm3
-	vpmullw	%ymm14, %ymm1, %ymm11
-	vpaddw	%ymm6, %ymm4, %ymm6
+	vpsubw	%ymm2, %ymm7, %ymm15
+	vpsubw	%ymm3, %ymm11, %ymm9
+	vpsubw	%ymm6, %ymm10, %ymm12
+	vpaddw	%ymm7, %ymm2, %ymm2
+	vpaddw	%ymm11, %ymm3, %ymm3
+	vpmullw	%ymm15, %ymm1, %ymm11
+	vpaddw	%ymm10, %ymm6, %ymm6
 	vpmullw	%ymm9, %ymm1, %ymm13
-	vpsubw	%ymm15, %ymm8, %ymm10
-	vpaddw	%ymm8, %ymm15, %ymm7
+	vpsubw	%ymm4, %ymm8, %ymm10
+	vpaddw	%ymm8, %ymm4, %ymm7
 	vpmullw	%ymm12, %ymm1, %ymm4
 	vpmullw	%ymm10, %ymm1, %ymm8
-	vpmulhw	%ymm14, %ymm5, %ymm15
+	vpmulhw	%ymm15, %ymm5, %ymm15
 	vpmulhw	%ymm9, %ymm5, %ymm9
 	vpmulhw	%ymm12, %ymm5, %ymm12
 	vpmulhw	%ymm10, %ymm5, %ymm10
@@ -13081,13 +12791,13 @@ L_poly_invntt$1:
 	vpsubw	%ymm11, %ymm15, %ymm11
 	vpsubw	%ymm13, %ymm9, %ymm9
 	vpsubw	%ymm4, %ymm12, %ymm12
-	vpsubw	%ymm8, %ymm10, %ymm15
+	vpsubw	%ymm8, %ymm10, %ymm10
 	vmovdqu	glob_data + 1056(%rip), %ymm4
 	vmovdqu	glob_data + 1088(%rip), %ymm8
 	vmovdqu	%ymm11, 256(%rcx)
 	vmovdqu	%ymm9, 288(%rcx)
 	vmovdqu	%ymm12, 320(%rcx)
-	vmovdqu	%ymm15, 352(%rcx)
+	vmovdqu	%ymm10, 352(%rcx)
 	vpmullw	%ymm2, %ymm4, %ymm12
 	vpmulhw	%ymm2, %ymm8, %ymm2
 	vpmulhw	%ymm0, %ymm12, %ymm12
@@ -13113,22 +12823,22 @@ L_poly_invntt$1:
 	vmovdqu	448(%rcx), %ymm12
 	vmovdqu	480(%rcx), %ymm7
 	vmovdqu	128(%rcx), %ymm9
-	vmovdqu	160(%rcx), %ymm13
+	vmovdqu	160(%rcx), %ymm14
 	vmovdqu	192(%rcx), %ymm6
 	vmovdqu	224(%rcx), %ymm11
-	vpsubw	%ymm3, %ymm9, %ymm14
-	vpsubw	%ymm10, %ymm13, %ymm8
+	vpsubw	%ymm3, %ymm9, %ymm15
+	vpsubw	%ymm10, %ymm14, %ymm8
 	vpsubw	%ymm12, %ymm6, %ymm4
 	vpaddw	%ymm9, %ymm3, %ymm2
-	vpaddw	%ymm13, %ymm10, %ymm3
-	vpmullw	%ymm14, %ymm1, %ymm9
+	vpaddw	%ymm14, %ymm10, %ymm3
+	vpmullw	%ymm15, %ymm1, %ymm9
 	vpaddw	%ymm6, %ymm12, %ymm6
 	vpmullw	%ymm8, %ymm1, %ymm13
 	vpsubw	%ymm7, %ymm11, %ymm10
 	vpaddw	%ymm11, %ymm7, %ymm7
 	vpmullw	%ymm4, %ymm1, %ymm12
 	vpmullw	%ymm10, %ymm1, %ymm1
-	vpmulhw	%ymm14, %ymm5, %ymm14
+	vpmulhw	%ymm15, %ymm5, %ymm15
 	vpmulhw	%ymm8, %ymm5, %ymm8
 	vpmulhw	%ymm4, %ymm5, %ymm4
 	vpmulhw	%ymm10, %ymm5, %ymm10
@@ -13136,16 +12846,16 @@ L_poly_invntt$1:
 	vpmulhw	%ymm13, %ymm0, %ymm11
 	vpmulhw	%ymm12, %ymm0, %ymm12
 	vpmulhw	%ymm1, %ymm0, %ymm1
-	vpsubw	%ymm9, %ymm14, %ymm5
+	vpsubw	%ymm9, %ymm15, %ymm5
 	vpsubw	%ymm11, %ymm8, %ymm9
 	vpsubw	%ymm12, %ymm4, %ymm12
-	vpsubw	%ymm1, %ymm10, %ymm15
+	vpsubw	%ymm1, %ymm10, %ymm10
 	vmovdqu	glob_data + 1056(%rip), %ymm4
 	vmovdqu	glob_data + 1088(%rip), %ymm8
 	vmovdqu	%ymm5, 384(%rcx)
 	vmovdqu	%ymm9, 416(%rcx)
 	vmovdqu	%ymm12, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm10, 480(%rcx)
 	vpmullw	%ymm2, %ymm4, %ymm5
 	vpmulhw	%ymm2, %ymm8, %ymm1
 	vpmulhw	%ymm0, %ymm5, %ymm5
@@ -14088,8 +13798,8 @@ L_i_poly_frombytes$1:
 	vpblendw	$170, %ymm11, %ymm4, %ymm11
 	vpsrld	$16, %ymm4, %ymm3
 	vpblendw	$170, %ymm6, %ymm3, %ymm6
-	vpslld	$16, %ymm2, %ymm14
-	vpblendw	$170, %ymm14, %ymm5, %ymm14
+	vpslld	$16, %ymm2, %ymm15
+	vpblendw	$170, %ymm15, %ymm5, %ymm15
 	vpsrld	$16, %ymm5, %ymm3
 	vpblendw	$170, %ymm2, %ymm3, %ymm3
 	vpslld	$16, %ymm1, %ymm2
@@ -14102,10 +13812,10 @@ L_i_poly_frombytes$1:
 	vpand	%ymm11, %ymm0, %ymm2
 	vpand	%ymm12, %ymm0, %ymm12
 	vpsrlw	$8, %ymm6, %ymm4
-	vpsllw	$8, %ymm14, %ymm5
+	vpsllw	$8, %ymm15, %ymm5
 	vpor	%ymm5, %ymm4, %ymm4
 	vpand	%ymm4, %ymm0, %ymm4
-	vpsrlw	$4, %ymm14, %ymm5
+	vpsrlw	$4, %ymm15, %ymm5
 	vpand	%ymm5, %ymm0, %ymm5
 	vpsrlw	$12, %ymm3, %ymm6
 	vpsllw	$4, %ymm8, %ymm7
@@ -14127,31 +13837,31 @@ L_i_poly_frombytes$1:
 	vmovdqu	%ymm7, 192(%rsi)
 	vmovdqu	%ymm8, 224(%rsi)
 	vmovdqu	192(%r9), %ymm2
-	vmovdqu	224(%r9), %ymm3
+	vmovdqu	224(%r9), %ymm1
 	vmovdqu	256(%r9), %ymm4
-	vmovdqu	288(%r9), %ymm1
-	vmovdqu	320(%r9), %ymm5
-	vmovdqu	352(%r9), %ymm7
-	vperm2i128	$32, %ymm1, %ymm2, %ymm8
-	vperm2i128	$49, %ymm1, %ymm2, %ymm6
-	vperm2i128	$32, %ymm5, %ymm3, %ymm1
-	vperm2i128	$49, %ymm5, %ymm3, %ymm9
-	vperm2i128	$32, %ymm7, %ymm4, %ymm5
-	vperm2i128	$49, %ymm7, %ymm4, %ymm7
-	vpunpcklqdq	%ymm9, %ymm8, %ymm10
-	vpunpckhqdq	%ymm9, %ymm8, %ymm2
-	vpunpcklqdq	%ymm5, %ymm6, %ymm3
-	vpunpckhqdq	%ymm5, %ymm6, %ymm5
-	vpunpcklqdq	%ymm7, %ymm1, %ymm6
-	vpunpckhqdq	%ymm7, %ymm1, %ymm1
-	vmovsldup	%ymm5, %ymm11
-	vpblendd	$170, %ymm11, %ymm10, %ymm4
-	vpsrlq	$32, %ymm10, %ymm7
-	vpblendd	$170, %ymm5, %ymm7, %ymm5
+	vmovdqu	288(%r9), %ymm3
+	vmovdqu	320(%r9), %ymm10
+	vmovdqu	352(%r9), %ymm5
+	vperm2i128	$32, %ymm3, %ymm2, %ymm8
+	vperm2i128	$49, %ymm3, %ymm2, %ymm6
+	vperm2i128	$32, %ymm10, %ymm1, %ymm7
+	vperm2i128	$49, %ymm10, %ymm1, %ymm1
+	vperm2i128	$32, %ymm5, %ymm4, %ymm9
+	vperm2i128	$49, %ymm5, %ymm4, %ymm5
+	vpunpcklqdq	%ymm1, %ymm8, %ymm10
+	vpunpckhqdq	%ymm1, %ymm8, %ymm2
+	vpunpcklqdq	%ymm9, %ymm6, %ymm3
+	vpunpckhqdq	%ymm9, %ymm6, %ymm6
+	vpunpcklqdq	%ymm5, %ymm7, %ymm8
+	vpunpckhqdq	%ymm5, %ymm7, %ymm1
 	vmovsldup	%ymm6, %ymm11
-	vpblendd	$170, %ymm11, %ymm2, %ymm7
+	vpblendd	$170, %ymm11, %ymm10, %ymm4
+	vpsrlq	$32, %ymm10, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm5
+	vmovsldup	%ymm8, %ymm6
+	vpblendd	$170, %ymm6, %ymm2, %ymm7
 	vpsrlq	$32, %ymm2, %ymm2
-	vpblendd	$170, %ymm6, %ymm2, %ymm6
+	vpblendd	$170, %ymm8, %ymm2, %ymm6
 	vmovsldup	%ymm1, %ymm2
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
 	vpsrlq	$32, %ymm3, %ymm3
@@ -14160,8 +13870,8 @@ L_i_poly_frombytes$1:
 	vpblendw	$170, %ymm11, %ymm4, %ymm11
 	vpsrld	$16, %ymm4, %ymm3
 	vpblendw	$170, %ymm6, %ymm3, %ymm6
-	vpslld	$16, %ymm2, %ymm14
-	vpblendw	$170, %ymm14, %ymm5, %ymm14
+	vpslld	$16, %ymm2, %ymm15
+	vpblendw	$170, %ymm15, %ymm5, %ymm15
 	vpsrld	$16, %ymm5, %ymm3
 	vpblendw	$170, %ymm2, %ymm3, %ymm3
 	vpslld	$16, %ymm1, %ymm2
@@ -14174,10 +13884,10 @@ L_i_poly_frombytes$1:
 	vpand	%ymm11, %ymm0, %ymm2
 	vpand	%ymm12, %ymm0, %ymm12
 	vpsrlw	$8, %ymm6, %ymm4
-	vpsllw	$8, %ymm14, %ymm5
+	vpsllw	$8, %ymm15, %ymm5
 	vpor	%ymm5, %ymm4, %ymm4
 	vpand	%ymm4, %ymm0, %ymm4
-	vpsrlw	$4, %ymm14, %ymm5
+	vpsrlw	$4, %ymm15, %ymm5
 	vpand	%ymm5, %ymm0, %ymm5
 	vpsrlw	$12, %ymm3, %ymm6
 	vpsllw	$4, %ymm8, %ymm7
@@ -14596,11 +14306,11 @@ L_poly_basemul$1:
 	vpackusdw	%ymm4, %ymm5, %ymm4
 	vpmullw	%ymm1, %ymm6, %ymm5
 	vpmulhw	%ymm0, %ymm5, %ymm5
-	vpsubw	%ymm5, %ymm7, %ymm5
-	vpmullw	%ymm1, %ymm8, %ymm6
-	vpmulhw	%ymm0, %ymm6, %ymm0
+	vpsubw	%ymm5, %ymm7, %ymm2
+	vpmullw	%ymm1, %ymm8, %ymm5
+	vpmulhw	%ymm0, %ymm5, %ymm0
 	vpsubw	%ymm0, %ymm4, %ymm4
-	vmovdqu	%ymm5, 448(%rcx)
+	vmovdqu	%ymm2, 448(%rcx)
 	vmovdqu	%ymm4, 480(%rcx)
 	ret
 L_poly_csubq$1:
@@ -14779,8 +14489,8 @@ L_shake256_A32__A1600$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdx
 	vmovq	%rdx, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14797,19 +14507,19 @@ L_shake256_A32__A1600$1:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdx
 	vpinsrq	$1, %rdx, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -14821,8 +14531,8 @@ L_shake256_A32__A1600$9:
 L_shake256_A32__A1600$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14839,19 +14549,19 @@ L_shake256_A32__A1600$7:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -14884,25 +14594,25 @@ L_shake256_A32__A1600$6:
 	vpxor	%ymm9, %ymm9, %ymm9
 	movq	$0, %rdx
 	vpinsrq	$1, %rdx, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
-	movq	$1, %rdx
-	shlq	$63, %rdx
-	vmovq	%rdx, %xmm7
+	movq	$1, %rcx
+	shlq	$63, %rcx
+	vmovq	%rcx, %xmm7
 	vpxor	%ymm8, %ymm8, %ymm8
 	vinserti128	$0, %xmm7, %ymm8, %ymm8
 	vpxor	%ymm8, %ymm0, %ymm0
@@ -14921,14 +14631,14 @@ L_shake256_A32__A1600$5:
 	movq	%rdi, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm12
-	vmovdqu	%ymm12, 48(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm11
+	vmovdqu	%ymm11, 48(%rsi,%rcx)
 	movq	%xmm9, %rdi
 	movq	%rdi, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm9
+	vpblendd	$195, %ymm12, %ymm8, %ymm9
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdi
 	movq	%rdi, 120(%rsi,%rcx)
@@ -14942,8 +14652,8 @@ L_shake256_A32__A1600$3:
 	call	L_keccakf1600_avx2$1
 L_shake256_A32__A1600$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm4
-	vmovdqu	%xmm4, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm7
+	vmovdqu	%xmm7, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -14958,8 +14668,8 @@ L_sha3_256A_A1568$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -14976,19 +14686,19 @@ L_sha3_256A_A1568$1:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15000,8 +14710,8 @@ L_sha3_256A_A1568$9:
 L_sha3_256A_A1568$7:
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %ymm14
@@ -15018,19 +14728,19 @@ L_sha3_256A_A1568$7:
 	vinserti128	$1, %xmm10, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15043,8 +14753,8 @@ L_sha3_256A_A1568$6:
 	jb  	L_sha3_256A_A1568$7
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15063,19 +14773,19 @@ L_sha3_256A_A1568$6:
 	vpxor	%ymm9, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15100,19 +14810,19 @@ L_sha3_256A_A1568$5:
 	movq	%rdi, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm12
-	vmovdqu	%ymm12, 48(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm11
+	vmovdqu	%ymm11, 48(%rsi,%rcx)
 	movq	%xmm9, %rdi
 	movq	%rdi, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm9
+	vpblendd	$195, %ymm12, %ymm8, %ymm9
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
-	movq	%xmm7, %rdi
-	movq	%rdi, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm7
-	movq	%xmm7, 128(%rsi,%rcx)
+	movq	%xmm7, %r8
+	movq	%r8, 120(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm9
+	movq	%xmm9, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_sha3_256A_A1568$3:
@@ -15121,8 +14831,8 @@ L_sha3_256A_A1568$3:
 	call	L_keccakf1600_avx2$1
 L_sha3_256A_A1568$2:
 	movq	%xmm4, (%rsi,%rcx)
-	vmovdqu	%xmm3, %xmm4
-	vmovdqu	%xmm4, 8(%rsi,%rcx)
+	vmovdqu	%xmm3, %xmm7
+	vmovdqu	%xmm7, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm3, %xmm3
 	movq	%xmm3, 24(%rsi,%rcx)
 	ret
@@ -15340,8 +15050,8 @@ L_shake128x4_absorb_A32_A2$2:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %r9
 	shlq	$63, %r9
-	vmovq	%r9, %xmm4
-	vpbroadcastq	%xmm4, %ymm8
+	vmovq	%r9, %xmm7
+	vpbroadcastq	%xmm7, %ymm8
 	vpxor	640(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 640(%r8)
 	ret
@@ -15411,8 +15121,8 @@ L_shake256x4_A128__A32_A1$7:
 	xorq	%r13, 24(%r8,%r12,8)
 	movq	$1, %rcx
 	shlq	$63, %rcx
-	vmovq	%rcx, %xmm4
-	vpbroadcastq	%xmm4, %ymm8
+	vmovq	%rcx, %xmm7
+	vpbroadcastq	%xmm7, %ymm8
 	vpxor	512(%r8), %ymm8, %ymm8
 	vmovdqu	%ymm8, 512(%r8)
 	movq	$0, %rcx
@@ -15473,21 +15183,21 @@ L_shake256_A128__A32_A1$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rdi,%rcx), %xmm9
 	movq	24(%rdi,%rcx), %rdx
-	vmovq	%rdx, %xmm7
+	vmovq	%rdx, %xmm10
 	movq	$0, %rdx
-	vpinsrq	$1, %rdx, %xmm7, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm10, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	$0, %rcx
-	vpxor	%ymm7, %ymm7, %ymm7
-	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%ymm9, %ymm9, %ymm9
+	vpxor	%xmm10, %xmm10, %xmm10
 	movq	$0, %rdx
 	movzbq	(%rax,%rcx), %rax
 	orq 	$7936, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm9, %xmm10
-	vinserti128	$1, %xmm10, %ymm7, %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm10, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15500,8 +15210,8 @@ L_shake256_A128__A32_A1$1:
 L_shake256_A128__A32_A1$4:
 	call	L_keccakf1600_avx2$1
 L_shake256_A128__A32_A1$5:
-	vmovdqu	%xmm4, %xmm7
-	movq	%xmm7, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm9
+	movq	%xmm9, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vmovdqu	%xmm5, %xmm9
 	vextracti128	$1, %ymm5, %xmm7
@@ -15509,19 +15219,19 @@ L_shake256_A128__A32_A1$5:
 	movq	%rdx, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm12
-	vmovdqu	%ymm12, 48(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm11
+	vmovdqu	%ymm11, 48(%rsi,%rcx)
 	movq	%xmm9, %rdx
 	movq	%rdx, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm9
+	vpblendd	$195, %ymm12, %ymm8, %ymm9
 	vmovdqu	%ymm9, 88(%rsi,%rcx)
 	movq	%xmm7, %rdx
 	movq	%rdx, 120(%rsi,%rcx)
-	vpblendd	$195, %ymm10, %ymm13, %ymm7
-	movq	%xmm7, 128(%rsi,%rcx)
+	vpblendd	$195, %ymm10, %ymm13, %ymm9
+	movq	%xmm9, 128(%rsi,%rcx)
 	addq	$136, %rcx
 	incq	%rax
 L_shake256_A128__A32_A1$3:
@@ -15537,13 +15247,13 @@ L_shake256_A128__A32_A1$2:
 	movq	%rdx, 40(%rsi,%rcx)
 	vpunpckhqdq	%xmm7, %xmm7, %xmm7
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
 	vpblendd	$195, %ymm8, %ymm10, %ymm3
 	vmovdqu	%ymm3, 48(%rsi,%rcx)
 	movq	%xmm9, %rdx
 	movq	%rdx, 80(%rsi,%rcx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm3
+	vpblendd	$195, %ymm12, %ymm8, %ymm3
 	vmovdqu	%ymm3, 88(%rsi,%rcx)
 	movq	%xmm7, %rdx
 	movq	%rdx, 120(%rsi,%rcx)
@@ -15559,8 +15269,8 @@ L_sha3_512A_A64$1:
 	movq	$0, %rcx
 	vpbroadcastq	(%rbp,%rcx), %ymm7
 	vpxor	%ymm7, %ymm4, %ymm4
-	vmovdqu	8(%rbp,%rcx), %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vmovdqu	8(%rbp,%rcx), %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	40(%rbp,%rcx), %rdi
 	vmovq	%rdi, %xmm7
 	vmovdqu	48(%rbp,%rcx), %xmm9
@@ -15579,19 +15289,19 @@ L_sha3_512A_A64$1:
 	vpxor	%ymm9, %ymm9, %ymm9
 	movq	$0, %rdi
 	vpinsrq	$1, %rdi, %xmm8, %xmm8
-	vpxor	%ymm12, %ymm12, %ymm12
-	vpblendd	$195, %ymm9, %ymm14, %ymm10
-	vpblendd	$195, %ymm13, %ymm12, %ymm11
+	vpxor	%ymm10, %ymm10, %ymm10
+	vpblendd	$195, %ymm9, %ymm14, %ymm11
+	vpblendd	$195, %ymm13, %ymm10, %ymm12
 	vpblendd	$195, %ymm14, %ymm13, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm14
-	vpblendd	$240, %ymm10, %ymm11, %ymm11
-	vpblendd	$195, %ymm12, %ymm9, %ymm10
+	vpblendd	$240, %ymm12, %ymm11, %ymm14
+	vpblendd	$240, %ymm11, %ymm12, %ymm11
+	vpblendd	$195, %ymm10, %ymm9, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm9
-	vpblendd	$240, %ymm10, %ymm13, %ymm12
+	vpblendd	$240, %ymm10, %ymm13, %ymm10
 	vpxor	%ymm14, %ymm0, %ymm0
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpxor	%ymm9, %ymm1, %ymm1
-	vpxor	%ymm12, %ymm6, %ymm6
+	vpxor	%ymm10, %ymm6, %ymm6
 	vmovdqu	%xmm8, %xmm10
 	vinserti128	$1, %xmm7, %ymm10, %ymm10
 	vpxor	%ymm10, %ymm5, %ymm5
@@ -15607,19 +15317,19 @@ L_sha3_512A_A64$1:
 L_sha3_512A_A64$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A64$5:
-	vmovdqu	%xmm4, %xmm7
-	movq	%xmm7, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm9
+	movq	%xmm9, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
 	movq	%xmm7, %rdi
 	movq	%rdi, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm7
-	vmovdqu	%xmm7, %xmm8
-	vmovdqu	%xmm8, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm7, %xmm7
-	movq	%xmm7, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm9
+	vmovdqu	%xmm9, %xmm7
+	vmovdqu	%xmm7, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm9, %xmm9
+	movq	%xmm9, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A64$3:
@@ -15650,14 +15360,14 @@ L_sha3_512A_A33$1:
 	vpxor	%ymm7, %ymm4, %ymm4
 	vmovdqu	8(%rbp,%rcx), %xmm9
 	movq	24(%rbp,%rcx), %rdx
-	vmovq	%rdx, %xmm7
+	vmovq	%rdx, %xmm10
 	movq	$0, %rdx
 	movzbq	32(%rbp,%rcx), %rax
 	orq 	$1536, %rax
 	orq 	%rax, %rdx
-	vpinsrq	$1, %rdx, %xmm7, %xmm7
-	vinserti128	$1, %xmm7, %ymm9, %ymm9
-	vpxor	%ymm9, %ymm3, %ymm3
+	vpinsrq	$1, %rdx, %xmm10, %xmm7
+	vinserti128	$1, %xmm7, %ymm9, %ymm7
+	vpxor	%ymm7, %ymm3, %ymm3
 	movq	$1, %rcx
 	shlq	$63, %rcx
 	vmovq	%rcx, %xmm7
@@ -15670,19 +15380,19 @@ L_sha3_512A_A33$1:
 L_sha3_512A_A33$4:
 	call	L_keccakf1600_avx2$1
 L_sha3_512A_A33$5:
-	vmovdqu	%xmm4, %xmm7
-	movq	%xmm7, (%rsi,%rcx)
+	vmovdqu	%xmm4, %xmm9
+	movq	%xmm9, (%rsi,%rcx)
 	vmovdqu	%ymm3, 8(%rsi,%rcx)
 	vextracti128	$1, %ymm5, %xmm7
-	movq	%xmm7, %r8
-	movq	%r8, 40(%rsi,%rcx)
+	movq	%xmm7, %rdx
+	movq	%rdx, 40(%rsi,%rcx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
-	vpblendd	$195, %ymm8, %ymm10, %ymm7
-	vmovdqu	%xmm7, %xmm8
-	vmovdqu	%xmm8, 48(%rsi,%rcx)
-	vextracti128	$1, %ymm7, %xmm7
-	movq	%xmm7, 64(%rsi,%rcx)
+	vpblendd	$195, %ymm8, %ymm10, %ymm9
+	vmovdqu	%xmm9, %xmm7
+	vmovdqu	%xmm7, 48(%rsi,%rcx)
+	vextracti128	$1, %ymm9, %xmm9
+	movq	%xmm9, 64(%rsi,%rcx)
 	addq	$72, %rcx
 	incq	%rax
 L_sha3_512A_A33$3:
@@ -15984,10 +15694,10 @@ L_keccakf1600_st25_avx2$1:
 	vinserti128	$1, %xmm7, %ymm10, %ymm5
 	vmovdqu	168(%rbx), %ymm6
 	vpblendd	$195, %ymm1, %ymm0, %ymm10
-	vpblendd	$195, %ymm2, %ymm6, %ymm11
+	vpblendd	$195, %ymm2, %ymm6, %ymm12
 	vpblendd	$195, %ymm0, %ymm2, %ymm13
-	vpblendd	$240, %ymm11, %ymm10, %ymm0
-	vpblendd	$240, %ymm10, %ymm11, %ymm2
+	vpblendd	$240, %ymm12, %ymm10, %ymm0
+	vpblendd	$240, %ymm10, %ymm12, %ymm2
 	vpblendd	$195, %ymm6, %ymm1, %ymm10
 	vpblendd	$240, %ymm13, %ymm10, %ymm1
 	vpblendd	$240, %ymm10, %ymm13, %ymm6
@@ -15996,7 +15706,7 @@ L_keccakf1600_st25_avx2$2:
 	vmovlpd	%xmm4, (%rbx)
 	vmovdqu	%ymm3, 8(%rbx)
 	vpblendd	$240, %ymm2, %ymm0, %ymm10
-	vpblendd	$240, %ymm0, %ymm2, %ymm11
+	vpblendd	$240, %ymm0, %ymm2, %ymm12
 	vpblendd	$240, %ymm6, %ymm1, %ymm13
 	vpblendd	$240, %ymm1, %ymm6, %ymm8
 	vextracti128	$1, %ymm5, %xmm7
@@ -16004,13 +15714,13 @@ L_keccakf1600_st25_avx2$2:
 	vpblendd	$195, %ymm8, %ymm10, %ymm0
 	vmovdqu	%ymm0, 48(%rbx)
 	vmovlpd	%xmm5, 80(%rbx)
-	vpblendd	$195, %ymm11, %ymm8, %ymm0
+	vpblendd	$195, %ymm12, %ymm8, %ymm0
 	vmovdqu	%ymm0, 88(%rbx)
 	vmovhpd	%xmm7, 120(%rbx)
 	vpblendd	$195, %ymm10, %ymm13, %ymm0
 	vmovdqu	%ymm0, 128(%rbx)
 	vmovhpd	%xmm5, 160(%rbx)
-	vpblendd	$195, %ymm13, %ymm11, %ymm0
+	vpblendd	$195, %ymm13, %ymm12, %ymm0
 	vmovdqu	%ymm0, 168(%rbx)
 	ret
 L_keccakf1600_avx2$1:
@@ -16111,7 +15821,7 @@ L__keccakf1600_avx2$2:
 	vpblendd	$192, %ymm2, %ymm12, %ymm12
 	vpandn	%ymm12, %ymm5, %ymm5
 	vpxor	%ymm8, %ymm5, %ymm5
-	vpermq	$0, %ymm6, %ymm14
+	vpermq	$0, %ymm6, %ymm15
 	vpermq	$27, %ymm0, %ymm0
 	vpermq	$141, %ymm1, %ymm1
 	vpermq	$114, %ymm9, %ymm6
@@ -16122,7 +15832,7 @@ L__keccakf1600_avx2$2:
 	vpblendd	$192, %ymm8, %ymm2, %ymm2
 	vpblendd	$192, %ymm10, %ymm12, %ymm12
 	vpandn	%ymm12, %ymm2, %ymm2
-	vpxor	%ymm14, %ymm4, %ymm4
+	vpxor	%ymm15, %ymm4, %ymm4
 	vpxor	%ymm7, %ymm3, %ymm3
 	vpxor	%ymm11, %ymm2, %ymm2
 	vpbroadcastq	(%r11,%r12,8), %ymm7
@@ -16156,26 +15866,26 @@ L_nttunpack$1:
 	vpunpckhqdq	%ymm8, %ymm4, %ymm1
 	vpunpcklqdq	%ymm13, %ymm5, %ymm6
 	vpunpckhqdq	%ymm13, %ymm5, %ymm5
-	vmovsldup	%ymm2, %ymm14
-	vpblendd	$170, %ymm14, %ymm7, %ymm4
+	vmovsldup	%ymm2, %ymm15
+	vpblendd	$170, %ymm15, %ymm7, %ymm4
 	vpsrlq	$32, %ymm7, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
-	vmovsldup	%ymm1, %ymm14
-	vpblendd	$170, %ymm14, %ymm9, %ymm3
+	vmovsldup	%ymm1, %ymm15
+	vpblendd	$170, %ymm15, %ymm9, %ymm3
 	vpsrlq	$32, %ymm9, %ymm7
 	vpblendd	$170, %ymm1, %ymm7, %ymm7
-	vmovsldup	%ymm6, %ymm14
-	vpblendd	$170, %ymm14, %ymm10, %ymm1
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm10, %ymm1
 	vpsrlq	$32, %ymm10, %ymm9
 	vpblendd	$170, %ymm6, %ymm9, %ymm6
-	vmovsldup	%ymm5, %ymm14
-	vpblendd	$170, %ymm14, %ymm11, %ymm8
+	vmovsldup	%ymm5, %ymm15
+	vpblendd	$170, %ymm15, %ymm11, %ymm8
 	vpsrlq	$32, %ymm11, %ymm9
 	vpblendd	$170, %ymm5, %ymm9, %ymm5
 	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm4, %ymm0
-	vpsrld	$16, %ymm4, %ymm9
-	vpblendw	$170, %ymm1, %ymm9, %ymm9
+	vpblendw	$170, %ymm11, %ymm4, %ymm9
+	vpsrld	$16, %ymm4, %ymm10
+	vpblendw	$170, %ymm1, %ymm10, %ymm0
 	vpslld	$16, %ymm6, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
 	vpsrld	$16, %ymm2, %ymm10
@@ -16183,83 +15893,83 @@ L_nttunpack$1:
 	vpslld	$16, %ymm8, %ymm2
 	vpblendw	$170, %ymm2, %ymm3, %ymm2
 	vpsrld	$16, %ymm3, %ymm3
-	vpblendw	$170, %ymm8, %ymm3, %ymm4
+	vpblendw	$170, %ymm8, %ymm3, %ymm3
 	vpslld	$16, %ymm5, %ymm6
-	vpblendw	$170, %ymm6, %ymm7, %ymm3
+	vpblendw	$170, %ymm6, %ymm7, %ymm6
 	vpsrld	$16, %ymm7, %ymm7
-	vpblendw	$170, %ymm5, %ymm7, %ymm15
-	vmovdqu	%ymm0, (%rcx)
-	vmovdqu	%ymm9, 32(%rcx)
+	vpblendw	$170, %ymm5, %ymm7, %ymm4
+	vmovdqu	%ymm9, (%rcx)
+	vmovdqu	%ymm0, 32(%rcx)
 	vmovdqu	%ymm1, 64(%rcx)
 	vmovdqu	%ymm13, 96(%rcx)
 	vmovdqu	%ymm2, 128(%rcx)
-	vmovdqu	%ymm4, 160(%rcx)
-	vmovdqu	%ymm3, 192(%rcx)
-	vmovdqu	%ymm15, 224(%rcx)
-	vmovdqu	256(%rcx), %ymm2
-	vmovdqu	288(%rcx), %ymm3
+	vmovdqu	%ymm3, 160(%rcx)
+	vmovdqu	%ymm6, 192(%rcx)
+	vmovdqu	%ymm4, 224(%rcx)
+	vmovdqu	256(%rcx), %ymm3
+	vmovdqu	288(%rcx), %ymm0
 	vmovdqu	320(%rcx), %ymm1
 	vmovdqu	352(%rcx), %ymm8
 	vmovdqu	384(%rcx), %ymm5
-	vmovdqu	416(%rcx), %ymm7
-	vmovdqu	448(%rcx), %ymm4
-	vmovdqu	480(%rcx), %ymm15
-	vperm2i128	$32, %ymm5, %ymm2, %ymm0
-	vperm2i128	$49, %ymm5, %ymm2, %ymm2
-	vperm2i128	$32, %ymm7, %ymm3, %ymm6
-	vperm2i128	$49, %ymm7, %ymm3, %ymm9
-	vperm2i128	$32, %ymm4, %ymm1, %ymm5
-	vperm2i128	$49, %ymm4, %ymm1, %ymm1
-	vperm2i128	$32, %ymm15, %ymm8, %ymm10
-	vperm2i128	$49, %ymm15, %ymm8, %ymm8
-	vpunpcklqdq	%ymm5, %ymm0, %ymm3
-	vpunpckhqdq	%ymm5, %ymm0, %ymm4
-	vpunpcklqdq	%ymm1, %ymm2, %ymm5
-	vpunpckhqdq	%ymm1, %ymm2, %ymm7
-	vpunpcklqdq	%ymm10, %ymm6, %ymm2
-	vpunpckhqdq	%ymm10, %ymm6, %ymm1
-	vpunpcklqdq	%ymm8, %ymm9, %ymm6
-	vpunpckhqdq	%ymm8, %ymm9, %ymm8
+	vmovdqu	416(%rcx), %ymm9
+	vmovdqu	448(%rcx), %ymm6
+	vmovdqu	480(%rcx), %ymm7
+	vperm2i128	$32, %ymm5, %ymm3, %ymm2
+	vperm2i128	$49, %ymm5, %ymm3, %ymm4
+	vperm2i128	$32, %ymm9, %ymm0, %ymm3
+	vperm2i128	$49, %ymm9, %ymm0, %ymm5
+	vperm2i128	$32, %ymm6, %ymm1, %ymm9
+	vperm2i128	$49, %ymm6, %ymm1, %ymm1
+	vperm2i128	$32, %ymm7, %ymm8, %ymm6
+	vperm2i128	$49, %ymm7, %ymm8, %ymm8
+	vpunpcklqdq	%ymm9, %ymm2, %ymm7
+	vpunpckhqdq	%ymm9, %ymm2, %ymm9
+	vpunpcklqdq	%ymm1, %ymm4, %ymm10
+	vpunpckhqdq	%ymm1, %ymm4, %ymm4
+	vpunpcklqdq	%ymm6, %ymm3, %ymm2
+	vpunpckhqdq	%ymm6, %ymm3, %ymm1
+	vpunpcklqdq	%ymm8, %ymm5, %ymm6
+	vpunpckhqdq	%ymm8, %ymm5, %ymm5
 	vmovsldup	%ymm2, %ymm11
-	vpblendd	$170, %ymm11, %ymm3, %ymm9
-	vpsrlq	$32, %ymm3, %ymm3
+	vpblendd	$170, %ymm11, %ymm7, %ymm11
+	vpsrlq	$32, %ymm7, %ymm3
 	vpblendd	$170, %ymm2, %ymm3, %ymm2
-	vmovsldup	%ymm1, %ymm11
-	vpblendd	$170, %ymm11, %ymm4, %ymm3
+	vmovsldup	%ymm1, %ymm15
+	vpblendd	$170, %ymm15, %ymm9, %ymm3
+	vpsrlq	$32, %ymm9, %ymm7
+	vpblendd	$170, %ymm1, %ymm7, %ymm7
+	vmovsldup	%ymm6, %ymm15
+	vpblendd	$170, %ymm15, %ymm10, %ymm1
+	vpsrlq	$32, %ymm10, %ymm9
+	vpblendd	$170, %ymm6, %ymm9, %ymm6
+	vmovsldup	%ymm5, %ymm15
+	vpblendd	$170, %ymm15, %ymm4, %ymm8
 	vpsrlq	$32, %ymm4, %ymm4
-	vpblendd	$170, %ymm1, %ymm4, %ymm4
-	vmovsldup	%ymm6, %ymm11
-	vpblendd	$170, %ymm11, %ymm5, %ymm1
-	vpsrlq	$32, %ymm5, %ymm5
-	vpblendd	$170, %ymm6, %ymm5, %ymm5
-	vmovsldup	%ymm8, %ymm6
-	vpblendd	$170, %ymm6, %ymm7, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
-	vpblendd	$170, %ymm8, %ymm7, %ymm7
-	vpslld	$16, %ymm1, %ymm11
-	vpblendw	$170, %ymm11, %ymm9, %ymm0
-	vpsrld	$16, %ymm9, %ymm8
-	vpblendw	$170, %ymm1, %ymm8, %ymm9
-	vpslld	$16, %ymm5, %ymm11
+	vpblendd	$170, %ymm5, %ymm4, %ymm5
+	vpslld	$16, %ymm1, %ymm15
+	vpblendw	$170, %ymm15, %ymm11, %ymm9
+	vpsrld	$16, %ymm11, %ymm10
+	vpblendw	$170, %ymm1, %ymm10, %ymm0
+	vpslld	$16, %ymm6, %ymm11
 	vpblendw	$170, %ymm11, %ymm2, %ymm1
-	vpsrld	$16, %ymm2, %ymm8
-	vpblendw	$170, %ymm5, %ymm8, %ymm8
-	vpslld	$16, %ymm6, %ymm2
+	vpsrld	$16, %ymm2, %ymm10
+	vpblendw	$170, %ymm6, %ymm10, %ymm13
+	vpslld	$16, %ymm8, %ymm2
 	vpblendw	$170, %ymm2, %ymm3, %ymm2
 	vpsrld	$16, %ymm3, %ymm3
-	vpblendw	$170, %ymm6, %ymm3, %ymm10
-	vpslld	$16, %ymm7, %ymm6
-	vpblendw	$170, %ymm6, %ymm4, %ymm3
-	vpsrld	$16, %ymm4, %ymm14
-	vpblendw	$170, %ymm7, %ymm14, %ymm15
-	vmovdqu	%ymm0, 256(%rcx)
-	vmovdqu	%ymm9, 288(%rcx)
+	vpblendw	$170, %ymm8, %ymm3, %ymm3
+	vpslld	$16, %ymm5, %ymm6
+	vpblendw	$170, %ymm6, %ymm7, %ymm6
+	vpsrld	$16, %ymm7, %ymm7
+	vpblendw	$170, %ymm5, %ymm7, %ymm4
+	vmovdqu	%ymm9, 256(%rcx)
+	vmovdqu	%ymm0, 288(%rcx)
 	vmovdqu	%ymm1, 320(%rcx)
-	vmovdqu	%ymm8, 352(%rcx)
+	vmovdqu	%ymm13, 352(%rcx)
 	vmovdqu	%ymm2, 384(%rcx)
-	vmovdqu	%ymm10, 416(%rcx)
-	vmovdqu	%ymm3, 448(%rcx)
-	vmovdqu	%ymm15, 480(%rcx)
+	vmovdqu	%ymm3, 416(%rcx)
+	vmovdqu	%ymm6, 448(%rcx)
+	vmovdqu	%ymm4, 480(%rcx)
 	ret
 	.data
 	.p2align	5

--- a/code/jasmin/1024/avx2/kem.jinc
+++ b/code/jasmin/1024/avx2/kem.jinc
@@ -35,7 +35,7 @@ fn __crypto_kem_keypair_jazz(reg ptr u8[MLKEM_PUBLICKEYBYTES] pk, reg ptr u8[MLK
 
   for i = 0 to MLKEM_SYMBYTES/8
   {
-    t64 = randomnessp[:u64 MLKEM_SYMBYTES/8 + i];
+    t64 = randomnessp[#unaligned:u64 MLKEM_SYMBYTES/8 + i];
     sk.[:u64 ((MLKEM_POLYVECBYTES + MLKEM_PUBLICKEYBYTES + MLKEM_SYMBYTES)/8 + i)*8] = t64;
   }
 
@@ -59,7 +59,8 @@ fn __crypto_kem_enc_jazz(
 
   () = #spill(pk, shk);
 
-  buf[0:MLKEM_SYMBYTES] = #copy(randomnessp);
+  reg u256 b = randomnessp[#unaligned:u256 0];
+  buf[:u256 0] = b;
 
   buf[MLKEM_SYMBYTES:MLKEM_SYMBYTES] = _sha3_256A_A1568(buf[MLKEM_SYMBYTES:MLKEM_SYMBYTES], pk);
 

--- a/code/jasmin/1024/avx2/kem.jinc
+++ b/code/jasmin/1024/avx2/kem.jinc
@@ -71,7 +71,8 @@ fn __crypto_kem_enc_jazz(
 
   () = #unspill(shk);
 
-  shk = #copy(kr[0:MLKEM_SYMBYTES]);
+  reg u256 k = kr[:u256 0];
+  shk[#unaligned:u256 0] = k;
 
   return ct, shk;
 }

--- a/code/jasmin/1024/avx2/kem.jinc
+++ b/code/jasmin/1024/avx2/kem.jinc
@@ -119,8 +119,11 @@ fn __crypto_kem_dec_jazz(
 
   // No need for pointer arithmetic, but we will need to do some copying then as reg ptr = reg ptr is a noop
   // And concating both zp and ctp to make the SHAKE function easier to implement, read and understand
-
-  zp_ct[MLKEM_SYMBYTES:MLKEM_CIPHERTEXTBYTES] = #copy(ct);
+  inline int j;
+  for j = 0 to MLKEM_CIPHERTEXTBYTES / 32 {
+    reg u256 c = ct[#unaligned:u256 j];
+    zp_ct[:u256 (MLKEM_SYMBYTES / 32) + j] = c;
+  }
 
   /* fixme: should this be done in memory? */
   () = #unspill(shk);

--- a/code/jasmin/1024/avx2/kem.jinc
+++ b/code/jasmin/1024/avx2/kem.jinc
@@ -94,7 +94,8 @@ fn __crypto_kem_dec_jazz(
   reg u64 cnd;
 
   () = #spill(shk, ct);
-  zp_ct[0:MLKEM_SYMBYTES] = #copy(sk[MLKEM_SECRETKEYBYTES - MLKEM_SYMBYTES : MLKEM_SYMBYTES]);
+  reg u256 z = sk.[:u256 MLKEM_SECRETKEYBYTES - MLKEM_SYMBYTES];
+  zp_ct[:u256 0] = z;
 
   buf[0:MLKEM_INDCPA_MSGBYTES] = __indcpa_dec(buf[0:MLKEM_INDCPA_MSGBYTES], ct, sk[0:MLKEM_POLYVECBYTES]);
 

--- a/code/jasmin/1024/avx2/kem.jinc
+++ b/code/jasmin/1024/avx2/kem.jinc
@@ -100,8 +100,8 @@ fn __crypto_kem_dec_jazz(
 
   // we do not need to do pointer arithmetic here
 
-  /* fixme: should loads be 256-bits long? */
-  buf[MLKEM_SYMBYTES:MLKEM_SYMBYTES] = #copy(sk[MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES:MLKEM_SYMBYTES]);
+  reg u256 k = sk.[:u256 MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES];
+  buf[:u256 1] = k;
 
   //kr = _sha3_512_64(kr, buf);
   kr = _sha3_512A_A64(kr, buf);

--- a/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
+++ b/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
@@ -162,8 +162,9 @@ congr.
 wp; ecall (mlkem_correct_enc_1_avx2 pk{1}) => /=.
 auto => /> &1 &2; rewrite tP => *;do split;1:smt().
 move => ? r0 [r111 r12] /= [#]; rewrite !tP => *;do split;1,2:smt().
-move => *;rewrite !initiE 1,2:/# /= /get8 initiE 1:/# /= initiE 1:/# /= /get64_direct wordP => *.
-   rewrite /pack8_t /= /(\bits8) initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= /#. 
+move => *;rewrite !initiE 1,2:/# /= /get8 initiE 1:/# /= ifT 1://.
+rewrite /(\bits8) /get256_direct /pack32_t wordP => j hj.
+rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# initiE /#.
 qed.
 
 require import StdOrder. 

--- a/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
+++ b/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
@@ -402,29 +402,48 @@ seq 1 0 : (#pre /\
 ecall {1} (cmov_correct shk{1} (Array32.init (fun (i : int) => kr{1}.[0 + i])) cnd{1}).
 wp;ecall{1} (shake256_A32_A1600_ph zp_ct{1}).
 
+while{1} (inc = 49 /\ 0 <= j <= 49 /\
+ (forall i, 0 <= i < 32 => zp_ct.[i] = sk.[3136 + i]) /\
+ forall i, 0 <= i < j * 32 => zp_ct.[32 + i] = ct.[i]){1} (49 - j){1}.
++ move => &m z; auto => /> &hr jlo _ Hsk Hct jhi; do split; 1..2:smt().
+  + move => i ilo ihi.
+    rewrite initiE 1:/# /get8 /set256_direct WArray1600.WArray1600.initE ifT 1:/# /=.
+    rewrite ifF 1:/# WArray1600.WArray1600.initE ifT /#.
+  + move => i ilo ihi.
+    rewrite initiE 1:/# /get8 /set256_direct WArray1600.WArray1600.initE ifT 1:/# /=.
+    case: (i < j{hr} * 32) => ?.
+    + rewrite ifF 1:/# WArray1600.WArray1600.initE ifT /#.
+    rewrite ifT 1:/#.
+    rewrite /(\bits8) /get256_direct /pack32_t wordP => k hk.
+    rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# /= initiE /#.
+  + smt().
+
 + auto => /> &1 &2; rewrite  !tP =>??.
   have ->/= : (cph{2} = (cph{2}.`1,cph{2}.`2)) by smt(). 
   move =>[#]; rewrite !tP => cphv1 cphv2 ? Hkr1 ?ceq cdif.
-do split. 
+split; first split.
++ move => i ilo ihi.
+  rewrite initiE 1:/# /get8 /set256_direct WArray1600.WArray1600.initE ifT 1:/# /= ilo ihi /=.
+  rewrite /(\bits8) /get256_direct /pack32_t wordP => k hk.
+  rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# /= initiE /#.
++ smt().
+move => jL zp_ctL; split; first smt().
+move => A B C.
+have ? : jL = 49.
++ clear -A B C; smt().
+clear A B C; subst.
+move => eq_zp_ct_sk eq_zp_ct_ct.
+split.
 + move => badc back c0 c1.
   +  move : (c1 (cdif badc)).
     rewrite !tP => H k kb.
     rewrite (H k kb) !initiE 1,2:/# /=.
     rewrite /J; congr; congr;congr;congr.
-    + congr;rewrite tP => kk kkb; rewrite !initiE 1..3:/# /= ifF 1:/# initiE 1:/# /=kkb /=.
-      rewrite /(\bits8) /get256_direct /pack32_t wordP => j hj.
-      rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# /= initiE /#.
-    + congr;rewrite tP => kk kkb; rewrite !initiE 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /=.
-      clear -kkb cphv1.
-      rewrite /get8 initiE 1:/# /= initiE 1:/# /= /get64 /(\bits8) wordP => *.
-    rewrite initiE 1:/# /= /init8 /get64_direct /pack8_t initiE 1:/# /= initiE 1:/# /= initiE 1:/# /=.
-    rewrite cphv1 1:// initiE 1:// /#.
+    + congr; rewrite tP => kk kkb; rewrite !initiE 1..2:// /#.
+    + congr;rewrite tP => kk kkb; rewrite !initiE 1:// /=.
+      by rewrite (cphv1 _ kkb) initiE 1:// eq_zp_ct_ct 1:/#.
 
-  rewrite tP => kk kkb; rewrite !initiE 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /=.
-      clear -kkb cphv2.
-      rewrite /get8 initiE 1:/# /= initiE 1:/# /= /get64 /(\bits8) wordP => *.
-    rewrite initiE 1:/# /= /init8 /get64_direct /pack8_t initiE 1:/# /= initiE 1:/# /= initiE 1:/# /=.
-    rewrite cphv2 1:// initiE 1:// /= /#.
+  rewrite tP => kk kkb; rewrite !initiE 1:// /= (cphv2 _ kkb) initiE 1:// /#.
 
 move => goodc  back c0 c1.
   + move : (c0 (ceq goodc)).

--- a/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
+++ b/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
@@ -318,28 +318,28 @@ lemma mlkem_kem_correct_dec  :
        c1 = Array1408.init(fun i => ct{1}.[i]) /\
        c2 = Array160.init(fun i => ct{1}.[i + 1408])
        ==> ={res}].
-proc => /=. sp 0 1. swap {1} [4..5] 6.
+proc => /=. sp 0 1. swap {1} [4..5] 7.
 
 seq 4 1 : (#pre /\ aux{1} = m{2}); 
   1: by call (mlkem_correct_dec); 1: by auto => /> /#.
 
-seq 3 1 : (#pre /\ 
+seq 4 1 : (#pre /\
            (forall k, 0<=k<32 => buf{1}.[k] = m{2}.[k]) /\
            (forall k, 0<=k<32 => kr{1}.[k] = _K{2}.[k]) /\
            (forall k, 0<=k<32 => kr{1}.[k+32] = r{2}.[k])).
 ecall {1} (sha3_512A_A64_ph buf{1}).
 + auto => /> &1 &2; rewrite !tP => buf bvl bvh ; do split.
-  +  move => k kbl kbh; rewrite initiE 1:/# /= ifF 1:/# initiE 1:/# /#. 
+  + by move => k kbl kbh; rewrite initiE 1:/# /= ifF 1:/# /get8 !initiE 1..2:/# /= ifT.
   + move => k kbl kbh; rewrite initiE 1:/# /= kbh /= /G_mhpk; congr; congr;congr.
-    + rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifF 1: /# initiE /#.
-    rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifT 1: /# initiE 1:/# /= initiE 1:/# /=.
-    rewrite /get8 initiE 1:/# /= initiE 1:/# /= /get64 /(\bits8) wordP => *.
-    rewrite initiE 1:/# /= /init8 /get64_direct /pack8_t initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= /#.
+    + by rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifF 1:/# /get8 !initiE 1..2:/# /= ifT.
+    rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifT 1: /# initiE 1:/# /=.
+    rewrite /get256_direct /pack32_t /(\bits8) wordP => j hj.
+    rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# /= initiE /#.
   + move => k kbl kbh; rewrite initiE 1:/# /= ifF 1:/# /= /G_mhpk; congr; congr;congr.
-    + rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifF 1: /# initiE /#.
-    rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifT 1: /# initiE 1:/# /= initiE 1:/# /=.
-    rewrite /get8 initiE 1:/# /= initiE 1:/# /= /get64 /(\bits8) wordP => *.
-    rewrite initiE 1:/# /= /init8 /get64_direct /pack8_t initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= /#.
+    + rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifF 1: /# /get8 !initiE /#.
+    rewrite tP => i ib; rewrite initiE 1:/# /= initiE  1:/# /= ifT 1: /# initiE 1:/# /=.
+    rewrite /get256_direct /pack32_t /(\bits8) wordP => j hj.
+    rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# /= initiE /#.
 
 swap {2} 1 1.
 

--- a/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
+++ b/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
@@ -318,7 +318,7 @@ lemma mlkem_kem_correct_dec  :
        c1 = Array1408.init(fun i => ct{1}.[i]) /\
        c2 = Array160.init(fun i => ct{1}.[i + 1408])
        ==> ={res}].
-proc => /=. sp 0 1. swap {1} [4..5] 7.
+proc => /=. sp 0 1. swap {1} [4..6] 7.
 
 seq 4 1 : (#pre /\ aux{1} = m{2}); 
   1: by call (mlkem_correct_dec); 1: by auto => /> /#.
@@ -407,10 +407,9 @@ do split.
     rewrite !tP => H k kb.
     rewrite (H k kb) !initiE 1,2:/# /=.
     rewrite /J; congr; congr;congr;congr.
-    + congr;rewrite tP => kk kkb; rewrite !initiE 1..3:/# /= ifF 1:/# initiE 1:/# /=kkb /= initiE 1:/#.
-      clear -kkb.
-      rewrite /get8 initiE 1:/# /= initiE 1:/# /= /get64 /(\bits8) wordP => i Hi.
-    rewrite initiE 1:/# /= /init8 /get64_direct /pack8_t initiE 1:/# /= initiE 1:/# /= initiE 1:/# initiE 1:/# /= /#.
+    + congr;rewrite tP => kk kkb; rewrite !initiE 1..3:/# /= ifF 1:/# initiE 1:/# /=kkb /=.
+      rewrite /(\bits8) /get256_direct /pack32_t wordP => j hj.
+      rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# /= initiE /#.
     + congr;rewrite tP => kk kkb; rewrite !initiE 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /=.
       clear -kkb cphv1.
       rewrite /get8 initiE 1:/# /= initiE 1:/# /= /get64 /(\bits8) wordP => *.

--- a/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
+++ b/proof/correctness/1024/avx2/MLKEM_KEM_avx2.ec
@@ -132,7 +132,7 @@ lemma mlkem_kem_correct_enc  :
      k = res{1}.`2
 ].
 proc => /=;sp 0 1.
-seq 6 2 : (#pre /\
+seq 7 2 : (#pre /\
     Array32.init (fun (i : int) => kr{1}.[0 + i]) = _K{2} /\
     Array32.init (fun (i : int) => kr{1}.[32 + i]) = r{2} /\
     Array32.init (fun (i : int) => buf{1}.[i]) = m{2}).
@@ -141,8 +141,9 @@ seq 6 2 : (#pre /\
     
 auto => /> &1 &2;rewrite !tP => pk1 pk2; do split => *.
 + rewrite initiE 1:/# /= initiE 1:/# /= ifT 1:/# /= /G_mhpk;congr;congr;congr.
-   + rewrite tP => *; rewrite  initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /get8 initiE 1:/# /= initiE 1:/# /= /get64_direct wordP => *.
-   rewrite /pack8_t /= /(\bits8) initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= /#.
+   + rewrite tP => *; rewrite  initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= initiE 1:/# /= ifT 1:/# /=.
+     rewrite /(\bits8) /get256_direct /pack32_t wordP => j hj.
+     rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# initiE /#.
    + rewrite tP => *; rewrite  initiE 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /= /H_pk /SHA3_256_1568_32 get_of_list 1:/#;congr;congr;congr.
       + by congr; rewrite tP => i hi; rewrite pk1.
       + by congr; rewrite tP => i hi; rewrite pk2.
@@ -150,14 +151,16 @@ auto => /> &1 &2;rewrite !tP => pk1 pk2; do split => *.
 
 + rewrite initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= /G_mhpk;congr;congr;
 congr.
-   + rewrite tP => *; rewrite  initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /get8 initiE 1:/# /= initiE 1:/# /= /get64_direct wordP => *.
-   rewrite /pack8_t /= /(\bits8) initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= /#.
+   + rewrite tP => *; rewrite  initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= initiE 1:/# /= ifT 1:/# /=.
+     rewrite /(\bits8) /get256_direct /pack32_t wordP => j hj.
+     rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# initiE /#.
    + rewrite tP => *; rewrite  initiE 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /= /H_pk /SHA3_256_1568_32 get_of_list 1:/#;congr;congr;congr.
       + by congr;rewrite tP => i hi; rewrite pk1.
       + by congr;rewrite tP => i hi; rewrite pk2.
 
-+ rewrite initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= initiE 1:/# /= ifT 1:/# /= initiE 1:/# /= /get8 initiE 1:/# /= initiE 1:/# /= /get64_direct wordP => *.
-   rewrite /pack8_t /= /(\bits8) initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= initiE 1:/# /= /#.
++ rewrite initiE 1:/# /= initiE 1:/# /= ifF 1:/# /= initiE 1:/# /= ifT 1:/# /=.
+  rewrite /(\bits8) /get256_direct /pack32_t wordP => j hj.
+  rewrite initiE 1:// /= initiE 1:/# /= initiE 1:/# initiE /#.
 
 wp; ecall (mlkem_correct_enc_1_avx2 pk{1}) => /=.
 auto => /> &1 &2; rewrite tP => *;do split;1:smt().


### PR DESCRIPTION
Analogous to #102, but for MLKEM-1024.